### PR TITLE
Massive refactors and fixes

### DIFF
--- a/API/build.gradle
+++ b/API/build.gradle
@@ -4,5 +4,6 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.jetbrains:annotations:24.1.0'
     implementation group: 'org.spigotmc', name: 'spigot-api', version: '1.16.4-R0.1-SNAPSHOT'
 }

--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -7,9 +7,7 @@ archivesBaseName = "comzombies-Universal"
 
 repositories {
     mavenCentral()
-    maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-    maven { url 'https://oss.sonatype.org/content/repositories/central' }
+    maven { url 'https://repo.papermc.io/repository/maven-public/' }
     maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
     maven { url 'https://jitpack.io' }
 }
@@ -31,11 +29,10 @@ dependencies {
     implementation project(':NMS:1_16_R1')
     implementation project(':NMS:1_15_R1')
     implementation project(':NMS:1_14_R1')
+    implementation 'org.jetbrains:annotations:24.1.0'
+    implementation 'io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT'
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
-    implementation group: 'org.spigotmc', name: 'spigot-api', version: '1.16.4-R0.1-SNAPSHOT'
-    implementation group: 'org.spigotmc', name: 'spigot', version: '1.16.4-R0.1-SNAPSHOT'
-    implementation 'me.clip:placeholderapi:2.11.1'
-
+    implementation 'me.clip:placeholderapi:2.11.5'
 }
 
 jar {

--- a/Core/src/main/java/com/theprogrammingturkey/comz/commands/ArenaListCommand.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/commands/ArenaListCommand.java
@@ -4,6 +4,7 @@ import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.GameManager;
 import com.theprogrammingturkey.comz.util.COMZPermission;
 import com.theprogrammingturkey.comz.util.CommandUtil;
+import java.util.Locale;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -20,7 +21,8 @@ public class ArenaListCommand implements SubCommand
 
 		CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "---------------" + ChatColor.DARK_RED + "Arenas" + ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "---------------");
 		for(Game game : GameManager.INSTANCE.getGames())
-			CommandUtil.sendMessageToPlayer(player, ChatColor.RED + game.getName() + ": " + ChatColor.GREEN + "Players: " + game.getPlayersInGame().size() + ", Status: " + game.getMode().toString().toLowerCase());
+			CommandUtil.sendMessageToPlayer(player, ChatColor.RED + game.getName() + ": " + ChatColor.GREEN + "Players: " + game.getPlayersInGame().size() + ", Status: " + game.getMode().toString().toLowerCase(
+					Locale.ROOT));
 
 		return true;
 	}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/commands/CommandManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/commands/CommandManager.java
@@ -4,23 +4,24 @@ import com.theprogrammingturkey.comz.COMZombies;
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.GameManager;
 import com.theprogrammingturkey.comz.util.CommandUtil;
+import java.util.List;
+import java.util.Locale;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
 
-public class CommandManager implements CommandExecutor
-{
+public class CommandManager extends Command {
+
 	public static final CommandManager INSTANCE = new CommandManager();
 	private final HashMap<String, SubCommand> commandList = new HashMap<>();
 	private final HashMap<Player, ZombiesHelpCommand> helpCommand = new HashMap<>();
 
-	public CommandManager()
-	{
+	public CommandManager() {
+		super("zombies", "Type /zombies help for more info!", "", List.of("z", "zo", "zom"));
 		load();
 	}
 
@@ -211,73 +212,59 @@ public class CommandManager implements CommandExecutor
 		this.commandList.get(args[0]).onCommand(player, args);
 	}
 
-	@Override
-	public boolean onCommand(@Nonnull CommandSender sender, Command cmd, @Nonnull String label, @Nonnull String[] args)
-	{
-		Player player;
-		String command = cmd.getName();
-		if(command.equalsIgnoreCase("zombies"))
-		{
-			if(sender instanceof Player)
-			{
-				player = (Player) sender;
-			}
-			else
-			{
-				COMZombies.log.info("You must be in game to issue this command!");
-				return true;
-			}
-			if(args.length <= 0)
-			{
-				CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "Call of Minecraft: Zombies, By : " + ChatColor.GOLD + "IModZombies4Fun, turkey2349 and smeths!");
-				CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "Call of Minecraft: Zombies, By : " + ChatColor.GOLD + "Turkey2349, IModZombies4Fun and Smeths!");
-				CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + " Type /zombies help for a list of commands!");
-				return true;
-			}
-			else if(args[0].equalsIgnoreCase("setround"))
-			{
-				if(!player.isOp())
-					return true;
-				Game arena = GameManager.INSTANCE.getGame(args[1]);
-				if(arena == null)
-					return true;
-				else
-				{
-					for(int i = 0; i < Integer.parseInt(args[2]); i++)
-						arena.nextWave();
-					CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "Setting wave to: " + ChatColor.GOLD + args[2]);
-				}
-			}
-			else if(args[0].equalsIgnoreCase("version"))
-			{
-				CommandUtil.sendMessageToPlayer(player, COMZombies.getPlugin().getDescription().getVersion());
-				return true;
-			}
-			if(args[0].equalsIgnoreCase("help") || args[0].equalsIgnoreCase("h"))
-			{
-				ZombiesHelpCommand help;
-				if(helpCommand.get(player) == null)
-				{
-					help = new ZombiesHelpCommand(this, player);
-					helpCommand.put(player, help);
-					help.commandIssued(args);
-				}
-				else
-				{
-					help = helpCommand.get(player);
-					help.commandIssued(args);
-				}
-				return true;
-			}
-			if(commandList.containsKey(args[0].toLowerCase()))
-			{
-				this.commandList.get(args[0].toLowerCase()).onCommand(player, args);
-			}
-			else
-			{
-				CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "No such command! Type /zombies help for a list of commands!");
-			}
+	public boolean execute(@Nonnull CommandSender sender, @Nonnull String label,
+			@Nonnull String[] args) {
+		final Player player;
+		if (sender instanceof Player) {
+			player = (Player) sender;
+		} else {
+			COMZombies.log.info("You must be in game to issue this command!");
+			return true;
 		}
-		return false;
+		if (args.length == 0) {
+			CommandUtil.sendMessageToPlayer(player,
+					ChatColor.RED + "" + ChatColor.BOLD + "Call of Minecraft: Zombies, By : " + ChatColor.GOLD
+							+ "Turkey2349, IModZombies4Fun and Smeths!");
+			CommandUtil.sendMessageToPlayer(player,
+					ChatColor.RED + "" + ChatColor.BOLD + " Type /zombies help for a list of commands!");
+			return true;
+		} else if (args[0].equalsIgnoreCase("setround")) {
+			if (!player.isOp()) {
+				return true;
+			}
+			Game arena = GameManager.INSTANCE.getGame(args[1]);
+			if (arena == null) {
+				return true;
+			} else {
+				for (int i = 0; i < Integer.parseInt(args[2]); i++) {
+					arena.nextWave();
+				}
+				CommandUtil.sendMessageToPlayer(player,
+						ChatColor.RED + "Setting wave to: " + ChatColor.GOLD + args[2]);
+			}
+		} else if (args[0].equalsIgnoreCase("version")) {
+			CommandUtil.sendMessageToPlayer(player, COMZombies.getPlugin().getDescription().getVersion());
+			return true;
+		}
+		if (args[0].equalsIgnoreCase("help") || args[0].equalsIgnoreCase("h")) {
+			ZombiesHelpCommand help;
+			if (helpCommand.get(player) == null) {
+				help = new ZombiesHelpCommand(this, player);
+				helpCommand.put(player, help);
+				help.commandIssued(args);
+			} else {
+				help = helpCommand.get(player);
+				help.commandIssued(args);
+			}
+			return true;
+		}
+		if (commandList.containsKey(args[0].toLowerCase(Locale.ROOT))) {
+			this.commandList.get(args[0].toLowerCase(Locale.ROOT)).onCommand(player, args);
+		} else {
+			CommandUtil.sendMessageToPlayer(player,
+					ChatColor.RED + "No such command! Type /zombies help for a list of commands!");
+		}
+
+		return true;
 	}
 }

--- a/Core/src/main/java/com/theprogrammingturkey/comz/commands/EnableCommand.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/commands/EnableCommand.java
@@ -41,7 +41,6 @@ public class EnableCommand implements SubCommand
 						action.cancelAction();
 
 					game.setEnabled();
-					game.signManager.updateGame();
 					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Arena " + game.getName() + " has been enabled!");
 					return true;
 				}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/commands/InfoCommand.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/commands/InfoCommand.java
@@ -37,10 +37,9 @@ public class InfoCommand implements SubCommand
 			{
 				if(mode.equalsIgnoreCase("info"))
 				{
-					CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------" + ChatColor.GOLD + game.getName() + ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------");
+					CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------" + ChatColor.GOLD + game.getName() + ChatColor.RED + ChatColor.STRIKETHROUGH + "----------");
 					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "World: " + ChatColor.BLUE + game.arena.getWorld());
-					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Point One: x:" + ChatColor.BLUE + game.arena.getMin().getBlockX() + ChatColor.GREEN + ", y:" + ChatColor.BLUE + game.arena.getMin().getBlockY() + ChatColor.GREEN + ", z:" + ChatColor.BLUE + game.arena.getMin().getBlockZ());
-					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Point Two: x:" + ChatColor.BLUE + game.arena.getMax().getBlockX() + ChatColor.GREEN + ", y:" + ChatColor.BLUE + game.arena.getMax().getBlockY() + ChatColor.GREEN + ", z:" + ChatColor.BLUE + game.arena.getMax().getBlockZ());
+					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Bounding Box: " + ChatColor.BLUE + game.arena.getBoundingBox());
 					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Player Spawn: x:" + ChatColor.BLUE + game.getPlayerSpawn().getBlockX() + ChatColor.GREEN + ", y:" + ChatColor.BLUE + game.getPlayerSpawn().getBlockY() + ChatColor.GREEN + ", z:" + ChatColor.BLUE + game.getPlayerSpawn().getBlockZ());
 					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Lobby Spawn: x:" + ChatColor.BLUE + game.getLobbyLocation().getBlockX() + ChatColor.GREEN + ", y:" + ChatColor.BLUE + game.getLobbyLocation().getBlockY() + ChatColor.GREEN + ", z:" + ChatColor.BLUE + game.getLobbyLocation().getBlockZ());
 					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Spectator Spawn: x:" + ChatColor.BLUE + game.getSpectateLocation().getBlockX() + ChatColor.GREEN + ", y:" + ChatColor.BLUE + game.getSpectateLocation().getBlockY() + ChatColor.GREEN + ", z:" + ChatColor.BLUE + game.getSpectateLocation().getBlockZ());
@@ -59,7 +58,7 @@ public class InfoCommand implements SubCommand
 				}
 				else if(mode.equalsIgnoreCase("spawns") || mode.equalsIgnoreCase("spawn"))
 				{
-					CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------" + ChatColor.GOLD + "Spawn Points" + ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------");
+					CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------" + ChatColor.GOLD + "Spawn Points" + ChatColor.RED + ChatColor.STRIKETHROUGH + "----------");
 					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Total spawns: " + game.spawnManager.getTotalSpawns());
 					for(int i = 0; i < game.spawnManager.getTotalSpawns(); i++)
 					{
@@ -72,11 +71,10 @@ public class InfoCommand implements SubCommand
 				}
 				else if(mode.equalsIgnoreCase("doors") || mode.equalsIgnoreCase("door"))
 				{
-					CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------" + ChatColor.GOLD + "Spawn Points" + ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------");
+					CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------" + ChatColor.GOLD + "Spawn Points" + ChatColor.RED + ChatColor.STRIKETHROUGH + "----------");
 					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Total doors: " + game.doorManager.getDoors().size());
-					for(int i = 0; i < game.doorManager.getDoors().size(); i++)
+					for (Door door: game.doorManager.getDoors())
 					{
-						Door door = game.doorManager.getDoors().get(i);
 						CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Door " + door.doorID);
 						CommandUtil.sendMessageToPlayer(player, "  " + ChatColor.GREEN + "Blocks: " + ChatColor.BLUE + door.getBlocks().size());
 						CommandUtil.sendMessageToPlayer(player, "  " + ChatColor.GREEN + "Signs: " + ChatColor.BLUE + door.getSigns().size());
@@ -86,18 +84,17 @@ public class InfoCommand implements SubCommand
 				}
 				else if(mode.equalsIgnoreCase("zombies") || mode.equalsIgnoreCase("zombie"))
 				{
-					CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------" + ChatColor.GOLD + "Zombies" + ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------");
+					CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.STRIKETHROUGH + "----------" + ChatColor.GOLD + "Zombies" + ChatColor.RED + ChatColor.STRIKETHROUGH + "----------");
 					CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Total Zombies Alive: " + game.spawnManager.getEntities().size());
-					for(int i = 1; i <= game.spawnManager.getEntities().size(); i++)
+					for(int i = 0, size = game.spawnManager.getEntities().size(); i < size; i++)
 					{
-						int acc = i - 1;
-						CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Zombie " + i);
-						CommandUtil.sendMessageToPlayer(player, "  " + ChatColor.GREEN + "Is Dead: " + ChatColor.BLUE + game.spawnManager.getEntities().get(acc).isDead());
+						CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Zombie " + (i + 1));
+						CommandUtil.sendMessageToPlayer(player, "  " + ChatColor.GREEN + "Is Dead: " + ChatColor.BLUE + game.spawnManager.getEntities().get(i).isDead());
 						CommandUtil.sendMessageToPlayer(player, "  " + ChatColor.GREEN + "Location: ");
-						CommandUtil.sendMessageToPlayer(player, "    " + ChatColor.GREEN + "X: " + ChatColor.BLUE + game.spawnManager.getEntities().get(acc).getLocation().getBlockX());
-						CommandUtil.sendMessageToPlayer(player, "    " + ChatColor.GREEN + "Y: " + ChatColor.BLUE + game.spawnManager.getEntities().get(acc).getLocation().getBlockY());
-						CommandUtil.sendMessageToPlayer(player, "    " + ChatColor.GREEN + "Z: " + ChatColor.BLUE + game.spawnManager.getEntities().get(acc).getLocation().getBlockZ());
-						CommandUtil.sendMessageToPlayer(player, "  " + ChatColor.GREEN + "Health: " + ChatColor.BLUE + (game.spawnManager.getEntities().get(acc)));
+						CommandUtil.sendMessageToPlayer(player, "    " + ChatColor.GREEN + "X: " + ChatColor.BLUE + game.spawnManager.getEntities().get(i).getLocation().getBlockX());
+						CommandUtil.sendMessageToPlayer(player, "    " + ChatColor.GREEN + "Y: " + ChatColor.BLUE + game.spawnManager.getEntities().get(i).getLocation().getBlockY());
+						CommandUtil.sendMessageToPlayer(player, "    " + ChatColor.GREEN + "Z: " + ChatColor.BLUE + game.spawnManager.getEntities().get(i).getLocation().getBlockZ());
+						CommandUtil.sendMessageToPlayer(player, "  " + ChatColor.GREEN + "Health: " + ChatColor.BLUE + (game.spawnManager.getEntities().get(i)));
 					}
 				}
 

--- a/Core/src/main/java/com/theprogrammingturkey/comz/commands/JoinCommand.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/commands/JoinCommand.java
@@ -6,6 +6,7 @@ import com.theprogrammingturkey.comz.game.GameManager;
 import com.theprogrammingturkey.comz.game.GamePlayer;
 import com.theprogrammingturkey.comz.util.COMZPermission;
 import com.theprogrammingturkey.comz.util.CommandUtil;
+import java.util.Objects;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -16,15 +17,19 @@ public class JoinCommand implements SubCommand
 	@Override
 	public boolean onCommand(Player player, String[] args)
 	{
-		if(GameManager.INSTANCE.isPlayerInGame(player))
 		{
-			Map<Player, GamePlayer> gamePlayers = GameManager.INSTANCE.getGame(player).gamePlayers;
-			if(gamePlayers.get(player).hasLeftGame())
-				gamePlayers.remove(player);
-			else
-				CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "You must leave your current game first!");
-			return true;
+			final Game playerGame = GameManager.INSTANCE.getGame(player);
+			if (playerGame != null) {
+				if (Objects.requireNonNull(playerGame.getGamePlayer(player)).hasLeftGame()) {
+					playerGame.removePlayerFromGamePlayers(player);
+				} else {
+					CommandUtil.sendMessageToPlayer(player,
+							ChatColor.RED + "" + ChatColor.BOLD + "You must leave your current game first!");
+				}
+				return true;
+			}
 		}
+
 		if(GameManager.INSTANCE.getGames().isEmpty())
 		{
 			CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "There are no arenas!");

--- a/Core/src/main/java/com/theprogrammingturkey/comz/commands/LeaderboardsCommand.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/commands/LeaderboardsCommand.java
@@ -4,6 +4,7 @@ import com.theprogrammingturkey.comz.leaderboards.Leaderboard;
 import com.theprogrammingturkey.comz.leaderboards.StatsCategory;
 import com.theprogrammingturkey.comz.util.COMZPermission;
 import com.theprogrammingturkey.comz.util.CommandUtil;
+import java.util.Locale;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -23,17 +24,17 @@ public class LeaderboardsCommand implements SubCommand
 			CommandUtil.sendMessageToPlayer(player, ChatColor.DARK_RED + "Try /z leaderboard <catergory>");
 			StringBuilder cats = new StringBuilder();
 			for(StatsCategory cat : StatsCategory.values())
-				cats.append(cat.name().toLowerCase()).append(", ");
+				cats.append(cat.name().toLowerCase(Locale.ROOT)).append(", ");
 			cats.delete(cats.length() - 2, cats.length());
 			CommandUtil.sendMessageToPlayer(player, ChatColor.DARK_RED + "Categories: " + cats);
 		}
 		else if(args.length == 2)
 		{
 			//TODO: dynamic length
-			String catName = args[1].toLowerCase();
+			String catName = args[1].toLowerCase(Locale.ROOT);
 			for(StatsCategory cat : StatsCategory.values())
 			{
-				if(cat.name().toLowerCase().equals(catName))
+				if(cat.name().toLowerCase(Locale.ROOT).equals(catName))
 				{
 					Leaderboard.getTopX(cat, 15, player);
 					return true;
@@ -42,7 +43,7 @@ public class LeaderboardsCommand implements SubCommand
 			CommandUtil.sendMessageToPlayer(player, ChatColor.DARK_RED + catName + " is not a valid category! ");
 			StringBuilder cats = new StringBuilder();
 			for(StatsCategory cat : StatsCategory.values())
-				cats.append(cat.name().toLowerCase()).append(", ");
+				cats.append(cat.name().toLowerCase(Locale.ROOT)).append(", ");
 			cats.delete(cats.length() - 2, cats.length());
 			CommandUtil.sendMessageToPlayer(player, ChatColor.DARK_RED + "Categories: " + cats);
 		}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/commands/RejoinCommand.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/commands/RejoinCommand.java
@@ -24,10 +24,11 @@ public class RejoinCommand implements SubCommand
 			CommandUtil.noPermission(player, "rejoin the game");
 			return true;
 		}
-		if(game.wasDisconnected(player))
+		if(game.isDisconnectedPlayer(player)) {
 			game.addPlayer(player);
-		else
+		} else {
 			CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "You are already in the game!");
+		}
 
 		return false;
 	}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/config/COMZConfig.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/config/COMZConfig.java
@@ -1,5 +1,7 @@
 package com.theprogrammingturkey.comz.config;
 
+import org.jetbrains.annotations.NotNull;
+
 public enum COMZConfig
 {
 	ARENAS("arenas"),
@@ -8,24 +10,24 @@ public enum COMZConfig
 	STATS("stats"),
 	SIGNS("signs");
 
-	private final String name;
+	private final @NotNull String name;
 
-	COMZConfig(String name)
+	COMZConfig(@NotNull String name)
 	{
 		this.name = name;
 	}
 
-	public String getName()
+	public @NotNull String getName()
 	{
 		return name;
 	}
 
-	public String getLegacyFileName()
+	public @NotNull String getLegacyFileName()
 	{
 		return name + ".yml";
 	}
 
-	public String getFileName()
+	public @NotNull String getFileName()
 	{
 		return name + ".json";
 	}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/config/LegacyConfig.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/config/LegacyConfig.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.theprogrammingturkey.comz.COMZombies;
 import com.theprogrammingturkey.comz.game.features.PowerUp;
+import java.util.Locale;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -114,7 +115,8 @@ public class LegacyConfig
 			JsonObject powerupsStatusJson = new JsonObject();
 			for(PowerUp powerUp : PowerUp.values())
 				if(powerUp != PowerUp.NONE)
-					powerupsStatusJson.addProperty(powerUp.name(), oldConfig.getBoolean(key + ".powerups." + powerUp.name().toLowerCase(), true));
+					powerupsStatusJson.addProperty(powerUp.name(), oldConfig.getBoolean(key + ".powerups." + powerUp.name().toLowerCase(
+							Locale.ROOT), true));
 			powerupsJson.add("powerups", powerupsStatusJson);
 			arenaSettingsJson.add("powerup_settings", powerupsJson);
 
@@ -284,7 +286,7 @@ public class LegacyConfig
 
 					JsonArray spawns = new JsonArray();
 					String location = key + ".Doors.door" + doorID;
-					List<Integer> oldSpawns = oldConfig.getStringList(location + ".SpawnPoints").stream().map(Integer::parseInt).collect(Collectors.toList());
+					List<Integer> oldSpawns = oldConfig.getStringList(location + ".SpawnPoints").stream().map(Integer::parseInt).toList();
 					for(int spawn : oldSpawns)
 						spawns.add(spawn);
 

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/Arena.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/Arena.java
@@ -2,6 +2,7 @@ package com.theprogrammingturkey.comz.game;
 
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.util.BoundingBox;
 
 /**
  * Arena contained in every game.
@@ -12,12 +13,7 @@ public class Arena
 	/**
 	 * Location min, order in 3d world does not matter
 	 */
-	private Location min;
-
-	/**
-	 * Location max, order in 3d world does not matter
-	 */
-	private Location max;
+	private BoundingBox arenaBox;
 
 	/**
 	 * World in which min / max are contained, and the world the game is in.
@@ -27,35 +23,24 @@ public class Arena
 	/**
 	 * Constructs a new arena for a given game.
 	 *
-	 * @param minZone to be assigned to max
-	 * @param maxZone to be assigned to min
+	 * @param corner1 to be used to construct arenaBox
+	 * @param corner2 to be used to construct arenaBox
 	 * @param world   in which the game is contained in
 	 */
-	public Arena(Location minZone, Location maxZone, World world)
+	public Arena(Location corner1, Location corner2, World world)
 	{
-		min = minZone;
-		max = maxZone;
+		arenaBox = BoundingBox.of(corner1, corner2);
 		this.world = world;
 	}
 
 	/**
-	 * Sets the min to loc.
+	 * Sets the arenaBox to a bounding box.
 	 *
-	 * @param loc to be assigned to min
+	 * @param box to be assigned to arenaBox
 	 */
-	public void setMin(Location loc)
+	public void setBoundingBox(BoundingBox box)
 	{
-		min = loc;
-	}
-
-	/**
-	 * Sets the max to loc.
-	 *
-	 * @param loc to be assigned to max
-	 */
-	public void setMax(Location loc)
-	{
-		max = loc;
+		arenaBox = box;
 	}
 
 	/**
@@ -78,21 +63,10 @@ public class Arena
 	 */
 	public boolean containsBlock(Location currentLoc)
 	{
-		// Short circut eval.
-		if(currentLoc == null || currentLoc.getWorld() == null)
+		if(currentLoc == null || currentLoc.getWorld() != world)
 			return false;
 
-		if(currentLoc.getWorld() != world)
-			return false;
-
-		double x = currentLoc.getX();
-		double y = currentLoc.getY();
-		double z = currentLoc.getZ();
-
-		if(x <= Math.max(max.getBlockX(), min.getBlockX()) && x >= Math.min(max.getBlockX(), min.getBlockX()))
-			if(y <= Math.max(max.getBlockY(), min.getBlockY()) && y >= Math.min(max.getBlockY(), min.getBlockY()))
-				return z <= Math.max(max.getBlockZ(), min.getBlockZ()) && z >= Math.min(max.getBlockZ(), min.getBlockZ());
-		return false;
+		return arenaBox.contains(currentLoc.toVector());
 	}
 
 	/**
@@ -106,22 +80,12 @@ public class Arena
 	}
 
 	/**
-	 * Get the max location.
+	 * Get the bounding box of the arena.
 	 *
-	 * @return max
+	 * @return arenaBox
 	 */
-	public Location getMax()
+	public BoundingBox getBoundingBox()
 	{
-		return max;
-	}
-
-	/**
-	 * Get the min location.
-	 *
-	 * @return min
-	 */
-	public Location getMin()
-	{
-		return min;
+		return arenaBox.clone();
 	}
 }

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/CachedPlayerInfo.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/CachedPlayerInfo.java
@@ -9,10 +9,11 @@ import org.bukkit.inventory.ItemStack;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
 
 public class CachedPlayerInfo
 {
-	public static Map<Player, CachedPlayerInfo> savedPlayerInfo = new HashMap<>();
+	public static Map<UUID, CachedPlayerInfo> savedPlayerInfo = new HashMap<>();
 
 	private Location oldLoc;
 	private GameMode gameMode;
@@ -21,7 +22,7 @@ public class CachedPlayerInfo
 	private ItemStack[] invContents;
 	private ItemStack[] armorContents;
 
-	public static void savePlayerInfo(Player player)
+	public static void savePlayerInfo(@NotNull Player player)
 	{
 		CachedPlayerInfo info = new CachedPlayerInfo();
 		info.oldLoc = player.getLocation().clone();
@@ -31,15 +32,15 @@ public class CachedPlayerInfo
 		info.invContents = player.getInventory().getContents().clone();
 		info.armorContents = player.getInventory().getArmorContents().clone();
 		//don't overwrite existing info
-		if(!savedPlayerInfo.containsKey(player))
-			savedPlayerInfo.put(player, info);
+		if(!savedPlayerInfo.containsKey(player.getUniqueId()))
+			savedPlayerInfo.put(player.getUniqueId(), info);
 	}
 
-	public static void restorePlayerInfo(Player player)
+	public static void restorePlayerInfo(@NotNull Player player)
 	{
-		if(savedPlayerInfo.containsKey(player))
+		if(savedPlayerInfo.containsKey(player.getUniqueId()))
 		{
-			CachedPlayerInfo info = savedPlayerInfo.get(player);
+			CachedPlayerInfo info = savedPlayerInfo.get(player.getUniqueId());
 			COMZombies.scheduleTask(() -> player.teleport(info.oldLoc));
 			player.setGameMode(info.gameMode);
 			if(player.getAllowFlight())
@@ -47,7 +48,7 @@ public class CachedPlayerInfo
 			player.setTotalExperience(info.totalExp);
 			player.getInventory().setContents(info.invContents);
 			player.getInventory().setArmorContents(info.armorContents);
-			savedPlayerInfo.remove(player);
+			savedPlayerInfo.remove(player.getUniqueId());
 		}
 	}
 }

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/GameManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/GameManager.java
@@ -7,6 +7,7 @@ import com.theprogrammingturkey.comz.COMZombies;
 import com.theprogrammingturkey.comz.config.COMZConfig;
 import com.theprogrammingturkey.comz.config.ConfigManager;
 import com.theprogrammingturkey.comz.game.Game.ArenaStatus;
+import java.util.Collections;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -18,6 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 public class GameManager
 {
@@ -25,12 +29,12 @@ public class GameManager
 
 	private final List<Game> games = new ArrayList<>();
 
-	public List<Game> getGames()
+	public @UnmodifiableView List<Game> getGames()
 	{
-		return games;
+		return Collections.unmodifiableList(games);
 	}
 
-	public void removeGame(Game game)
+	public void removeGame(@NotNull Game game)
 	{
 		this.games.remove(game);
 	}
@@ -41,7 +45,7 @@ public class GameManager
 			game.endGame();
 	}
 
-	public Game getGame(Entity entity)
+	public @Nullable Game getGame(@NotNull Entity entity)
 	{
 		for(Game game : games)
 			for(Entity ent : game.spawnManager.getEntities())
@@ -68,7 +72,7 @@ public class GameManager
 			else
 				COMZombies.log.log(Level.SEVERE, COMZombies.CONSOLE_PREFIX + "Failed to load arena " + arena.getKey() + "!");
 		}
-		Bukkit.broadcastMessage(COMZombies.PREFIX + ChatColor.RED + ChatColor.BOLD + " Done loading arenas!");
+		Bukkit.broadcastMessage(COMZombies.PREFIX + ChatColor.RED + ChatColor.BOLD + "Done loading arenas!");
 	}
 
 	public void saveAllGames()
@@ -84,19 +88,19 @@ public class GameManager
 		for(Game gl : games)
 		{
 			for(Game game : games)
-				for(int q = 0; q < game.doorManager.getDoors().size(); q++)
-					game.doorManager.getDoors().get(q).closeDoor();
+				for(Door door: game.doorManager.getDoors())
+					door.closeDoor();
 			gl.endGame();
 			gl.resetSpawnLocationBlocks();
 		}
 	}
 
-	public void addArena(Game game)
+	public void addArena(@NotNull Game game)
 	{
 		games.add(game);
 	}
 
-	public Game getGame(Door door)
+	public @Nullable Game getGame(@NotNull Door door)
 	{
 		for(Game gl : games)
 			if(gl.doorManager.getDoors().contains(door))
@@ -104,10 +108,10 @@ public class GameManager
 		return null;
 	}
 
-	public Game getGame(Player player)
+	public @Nullable Game getGame(@NotNull Player player)
 	{
 		for(Game game : games)
-			if(game.isPlayerPlaying(player) || game.isPlayerSpectating(player) || game.wasDisconnected(player))
+			if(game.isPlayerPlaying(player) || game.isPlayerSpectating(player) || game.isDisconnectedPlayer(player))
 				return game;
 		return null;
 	}
@@ -120,7 +124,7 @@ public class GameManager
 		return false;
 	}
 
-	public Game getGame(String name)
+	public @Nullable Game getGame(@NotNull String name)
 	{
 		for(Game gl : games)
 			if(name.equalsIgnoreCase(gl.getName()))
@@ -174,7 +178,7 @@ public class GameManager
 		return false;
 	}
 
-	public Game getGame(Location loc)
+	public @Nullable Game getGame(@NotNull Location loc)
 	{
 		for(Game gl : games)
 			if(gl.arena != null && gl.arena.containsBlock(loc))

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/GameScoreboard.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/GameScoreboard.java
@@ -1,9 +1,11 @@
 package com.theprogrammingturkey.comz.game;
 
 import com.theprogrammingturkey.comz.economy.PointManager;
+import java.util.Objects;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Criteria;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Score;
@@ -12,17 +14,19 @@ import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.scoreboard.Team;
 
 import java.util.HashMap;
+import org.jetbrains.annotations.NotNull;
 
 public class GameScoreboard
 {
 
-	private final Game game;
-	private final ScoreboardManager manager = Bukkit.getScoreboardManager();
-	private final Scoreboard board;
-	private final Team team;
-	private final Objective objective;
-	private final Score round;
-	private final Score zombiesLeft;
+	private final @NotNull Game game;
+	private final @NotNull ScoreboardManager manager = Objects.requireNonNull(
+			Bukkit.getScoreboardManager());
+	private final @NotNull Scoreboard board;
+	private final @NotNull Team team;
+	private final @NotNull Objective objective;
+	private final @NotNull Score round;
+	private final @NotNull Score zombiesLeft;
 	private final HashMap<Player, Score> playerScores = new HashMap<>();
 
 	public GameScoreboard(Game game)
@@ -33,7 +37,7 @@ public class GameScoreboard
 		team.setDisplayName(ChatColor.RED + game.getName());
 		team.setCanSeeFriendlyInvisibles(true);
 		team.setAllowFriendlyFire(false);
-		objective = board.registerNewObjective(this.game.getName(), "dummy", ChatColor.RED + this.game.getName());
+		objective = board.registerNewObjective(this.game.getName(), Criteria.DUMMY, ChatColor.RED + this.game.getName());
 		objective.setDisplaySlot(DisplaySlot.SIDEBAR);
 		round = objective.getScore(ChatColor.RED + "Round");
 		round.setScore(0);
@@ -55,7 +59,6 @@ public class GameScoreboard
 				playerScores.get(player).setScore(500);
 			}
 		}
-		game.signManager.updateGame();
 	}
 
 	public void removePlayer(Player player)
@@ -64,7 +67,6 @@ public class GameScoreboard
 		board.resetScores(player.getName());
 		player.setScoreboard(manager.getNewScoreboard());
 		playerScores.remove(player);
-		game.signManager.updateGame();
 	}
 
 	public void update()
@@ -74,7 +76,5 @@ public class GameScoreboard
 
 		for(Player player : playerScores.keySet())
 			playerScores.get(player).setScore(PointManager.INSTANCE.getPlayersPoints(player));
-
-		game.signManager.updateGame();
 	}
 }

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/actions/ArenaSetupAction.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/actions/ArenaSetupAction.java
@@ -14,7 +14,7 @@ import org.bukkit.entity.Player;
 
 public class ArenaSetupAction extends BaseAction
 {
-	private int particleBoxID;
+	private int particleBoxId = -1;
 	private boolean runOnce = false;
 
 	private boolean setup = false;
@@ -38,7 +38,7 @@ public class ArenaSetupAction extends BaseAction
 	public void cancelAction()
 	{
 		if(runOnce)
-			Bukkit.getScheduler().cancelTask(particleBoxID);
+			Bukkit.getScheduler().cancelTask(particleBoxId);
 		if(!setup)
 			GameManager.INSTANCE.removeGame(game);
 
@@ -84,7 +84,7 @@ public class ArenaSetupAction extends BaseAction
 			if(game.gameSetupComplete(player))
 			{
 				if(runOnce)
-					Bukkit.getScheduler().cancelTask(particleBoxID);
+					Bukkit.getScheduler().cancelTask(particleBoxId);
 				COMZombies.getPlugin().activeActions.remove(player);
 
 				if(!setup)
@@ -105,11 +105,11 @@ public class ArenaSetupAction extends BaseAction
 			return;
 
 		if(runOnce)
-			Bukkit.getScheduler().cancelTask(particleBoxID);
+			Bukkit.getScheduler().cancelTask(particleBoxId);
 		else
 			runOnce = true;
 
-		particleBoxID = COMZombies.scheduleTask(0, 5, () ->
+		particleBoxId = COMZombies.scheduleTask(0, 5, () ->
 		{
 			Location min = new Location(world, Math.min(p1.getBlockX(), p2.getBlockX()), Math.min(p1.getBlockY(), p2.getBlockY()), Math.min(p1.getBlockZ(), p2.getBlockZ()));
 			Location max = new Location(world, Math.max(p1.getBlockX(), p2.getBlockX()), Math.max(p1.getBlockY(), p2.getBlockY()), Math.max(p1.getBlockZ(), p2.getBlockZ()));

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/actions/BarrierRemoveAction.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/actions/BarrierRemoveAction.java
@@ -27,12 +27,12 @@ public class BarrierRemoveAction extends BaseAction
 			BlockData blockData = block.getBlockData();
 			((Directional) blockData).setFacing(barrier.getSignFacing());
 			block.setBlockData(blockData);
-			Sign sign = (Sign) block.getState();
+			final Sign sign = (Sign) block.getState();
 			sign.setLine(0, "[BarrierRemove]");
 			sign.setLine(1, "Break this to");
 			sign.setLine(2, "remove the");
 			sign.setLine(3, "barrier");
-			sign.update(true);
+			sign.update();
 		}
 
 		CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "" + ChatColor.STRIKETHROUGH + "---------------" + ChatColor.DARK_RED + "Barrier Removal" + ChatColor.RED + "" + ChatColor.BOLD + "" + ChatColor.STRIKETHROUGH + "---------------");

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/actions/BarrierSetupAction.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/actions/BarrierSetupAction.java
@@ -30,7 +30,7 @@ public class BarrierSetupAction extends BaseAction
 		if(!player.getInventory().contains(Material.WOODEN_SWORD))
 			player.getInventory().addItem(new ItemStack(Material.WOODEN_SWORD));
 
-		CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "" + ChatColor.STRIKETHROUGH + "------" + ChatColor.DARK_RED + "Barrier Setup" + ChatColor.RED + "" + ChatColor.BOLD + "" + ChatColor.STRIKETHROUGH + "-----");
+		CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + ChatColor.STRIKETHROUGH + "------" + ChatColor.DARK_RED + "Barrier Setup" + ChatColor.RED + "" + ChatColor.BOLD + "" + ChatColor.STRIKETHROUGH + "-----");
 		CommandUtil.sendMessageToPlayer(player, ChatColor.GOLD + "Select each block individually to be the barrier using the wooden sword.");
 		CommandUtil.sendMessageToPlayer(player, ChatColor.GOLD + "Once you have this complete, type done, go into the room the barrier blocks to and click on any ender portal frames (spawn points) that is in there with the sword.");
 		CommandUtil.sendMessageToPlayer(player, ChatColor.GOLD + "Lastly! In chat, type a price for the each repairation stage of the barrier");

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/actions/DoorRemoveAction.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/actions/DoorRemoveAction.java
@@ -9,6 +9,7 @@ import com.theprogrammingturkey.comz.util.CommandUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -19,20 +20,18 @@ public class DoorRemoveAction extends BaseAction
 	{
 		super(player, game);
 
-		for(Door door : game.doorManager.getDoors())
-		{
-			for(Sign sign : door.getSigns())
-			{
-				if(!(sign.getBlock().getState() instanceof Sign))
-				{
-					sign.getBlock().setType(Material.OAK_WALL_SIGN);
+		for (final Door door : game.doorManager.getDoors()) {
+			for (final Location location : door.getSigns()) {
+				final Block block = location.getBlock();
+				if (!(block.getState() instanceof Sign)) {
+					location.getBlock().setType(Material.OAK_WALL_SIGN);
 				}
+				final Sign sign = (Sign) block.getState();
 				sign.setLine(0, ChatColor.RED + "Break a sign");
 				sign.setLine(1, ChatColor.RED + "to remove the");
 				sign.setLine(2, ChatColor.RED + "door that the");
 				sign.setLine(3, ChatColor.RED + "sign is for!");
 				sign.update();
-				sign.update(true);
 			}
 		}
 		CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "" + ChatColor.STRIKETHROUGH + "-------" + ChatColor.DARK_RED + "Door Removal" + ChatColor.RED + "" + ChatColor.BOLD + "" + ChatColor.STRIKETHROUGH + "-------");
@@ -49,12 +48,12 @@ public class DoorRemoveAction extends BaseAction
 			return;
 
 		event.setCancelled(true);
-		for(Sign sign : door.getSigns())
-			BlockUtils.setBlockToAir(sign.getBlock());
+
+		door.getSigns().forEach(BlockUtils::setBlockToAir);
 
 		CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "" + ChatColor.BOLD + "Door removed!");
 		game.doorManager.removeDoor(door);
-		if(game.doorManager.getDoors().size() == 0)
+		if(game.doorManager.getDoors().isEmpty())
 		{
 			CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "No doors left!");
 			cancelAction();

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/actions/DoorSetupAction.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/actions/DoorSetupAction.java
@@ -10,7 +10,6 @@ import com.theprogrammingturkey.comz.util.CommandUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -32,7 +31,7 @@ public class DoorSetupAction extends BaseAction
 		if(!player.getInventory().contains(Material.WOODEN_SWORD))
 			player.getInventory().addItem(new ItemStack(Material.WOODEN_SWORD));
 
-		CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "" + ChatColor.STRIKETHROUGH + "-------" + ChatColor.DARK_RED + "Door Setup" + ChatColor.RED + "" + ChatColor.BOLD + "" + ChatColor.STRIKETHROUGH + "-------");
+		CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + ChatColor.STRIKETHROUGH + "-------" + ChatColor.DARK_RED + "Door Setup" + ChatColor.RED + ChatColor.BOLD + ChatColor.STRIKETHROUGH + "-------");
 		CommandUtil.sendMessageToPlayer(player, ChatColor.GOLD + "Select each block individually to be the door using the wooden sword.");
 		CommandUtil.sendMessageToPlayer(player, ChatColor.GOLD + "Once you have this complete, type done, go into the room the door opens to and click on any ender portal frame (spawn point) that is in there with the sword.");
 		CommandUtil.sendMessageToPlayer(player, ChatColor.GOLD + "Once you have this complete, type done, find any signs that open this door and click them with the sword.");
@@ -69,10 +68,9 @@ public class DoorSetupAction extends BaseAction
 		if(state == 2 && (event.getAction().equals(Action.LEFT_CLICK_BLOCK) || event.getAction().equals(Action.RIGHT_CLICK_BLOCK)))
 		{
 			Block block = event.getClickedBlock();
-			if(BlockUtils.isSign(block.getType()))
+			if(BlockUtils.isSign(block.getBlockData()))
 			{
-				Sign sign = (Sign) event.getClickedBlock().getState();
-				door.addSign(sign);
+				door.addSign(block.getLocation());
 				event.setCancelled(true);
 				CommandUtil.sendMessageToPlayer(player, ChatColor.GREEN + "Sign selected!");
 			}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/features/DownedPlayer.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/features/DownedPlayer.java
@@ -9,6 +9,7 @@ import com.theprogrammingturkey.comz.game.managers.WeaponManager;
 import com.theprogrammingturkey.comz.game.weapons.WeaponInstance;
 import com.theprogrammingturkey.comz.leaderboards.Leaderboard;
 import com.theprogrammingturkey.comz.leaderboards.PlayerStats;
+import java.util.random.RandomGenerator;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
@@ -53,8 +54,7 @@ public class DownedPlayer implements Listener
 		guns[1] = manager.removeWeapon(2);
 		manager.removeWeapon(3);
 		manager.addWeapon(WeaponManager.getGun(game.getStartingGun()).getNewInstance(player, 1));
-		player.setGameMode(GameMode.CREATIVE);
-		player.setAllowFlight(false);
+		player.setInvulnerable(true);
 		player.setWalkSpeed(0.02f);
 		scheduleTask();
 	}
@@ -65,6 +65,7 @@ public class DownedPlayer implements Listener
 		isBeingRevived = false;
 		Bukkit.getScheduler().cancelTask(fireWorksTask);
 		player.setGameMode(GameMode.SURVIVAL);
+		player.setInvulnerable(false);
 		player.setWalkSpeed(0.2F);
 		player.setHealth(20);
 		reviver = null;
@@ -101,6 +102,9 @@ public class DownedPlayer implements Listener
 		this.isBeingRevived = true;
 		this.reviver = reviver;
 		int reviveTime = ConfigManager.getMainConfig().reviveTimer * 20;
+		if (game.perkManager.hasPerk(reviver, PerkType.QUICK_REVIVE)) {
+			reviveTime /= 5;
+		}
 		reviveTask = COMZombies.scheduleTask(reviveTime, this::revivePlayer);
 	}
 
@@ -135,26 +139,13 @@ public class DownedPlayer implements Listener
 
 	private FireworkEffect getRandomFireworkEffect()
 	{
-		boolean trail = Math.random() * 100 > 50;
+		RandomGenerator rand = COMZombies.rand;
 
-		boolean flickr = Math.random() * 100 > 50;
+		boolean trail = rand.nextBoolean();
+		boolean flickr = rand.nextBoolean();
 
-		int r = (int) (Math.random() * 255);
-		int g = (int) (Math.random() * 255);
-		int b = (int) (Math.random() * 255);
-		Color color = Color.fromRGB(r, g, b);
-		int rand = (int) (Math.random() * 5);
-		Type type;
-		if(rand == 0)
-			type = Type.BALL;
-		else if(rand == 1)
-			type = Type.BALL_LARGE;
-		else if(rand == 2)
-			type = Type.BURST;
-		else if(rand == 3)
-			type = Type.CREEPER;
-		else
-			type = Type.STAR;
+		Color color = Color.fromRGB(rand.nextInt(256), rand.nextInt(256), rand.nextInt(256));
+		Type type = Type.values()[rand.nextInt(Type.values().length)];
 
 		return FireworkEffect.builder().trail(trail).flicker(flickr).withColor(color).with(type).build();
 	}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/features/PerkType.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/features/PerkType.java
@@ -1,6 +1,7 @@
 package com.theprogrammingturkey.comz.game.features;
 
 import com.theprogrammingturkey.comz.COMZombies;
+import java.util.Locale;
 import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Material;
@@ -12,7 +13,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public enum PerkType
 {
@@ -30,7 +30,8 @@ public enum PerkType
 	public static PerkType getPerkType(String name)
 	{
 		for(PerkType pt : values())
-			if((ChatColor.GOLD + pt.toString()).equalsIgnoreCase(name) || (pt.toString().toLowerCase().equalsIgnoreCase(name)))
+			if((ChatColor.GOLD + pt.toString()).equalsIgnoreCase(name) || (pt.toString().toLowerCase(
+					Locale.ROOT).equalsIgnoreCase(name)))
 				return pt;
 		if(name.equalsIgnoreCase("der wunderfizz") || name.equalsIgnoreCase("wunderfizz") || name.equalsIgnoreCase("random"))
 			return DER_WUNDERFIZZ;
@@ -147,12 +148,11 @@ public enum PerkType
 
 	public static PerkType getRandomPerk(List<PerkType> exclude)
 	{
-		List<PerkType> availablePerks = Arrays.stream(PerkType.values()).filter(pt -> !exclude.contains(pt) && pt != PerkType.DER_WUNDERFIZZ).collect(Collectors.toList());
+		List<PerkType> availablePerks = Arrays.stream(PerkType.values()).filter(pt -> !exclude.contains(pt) && pt != PerkType.DER_WUNDERFIZZ).toList();
 
 		if(availablePerks.isEmpty())
 			return null;
-		//get random perk from list of available perks
-		int rand = (int) (Math.random() * availablePerks.size());
-		return availablePerks.get(rand);
+		// get random perk from list of available perks
+		return availablePerks.get(COMZombies.rand.nextInt(availablePerks.size()));
 	}
 }

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/BoxManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/BoxManager.java
@@ -39,7 +39,7 @@ public class BoxManager
 			if(!boxElem.isJsonObject())
 				continue;
 			JsonObject boxJson = boxElem.getAsJsonObject();
-			Location loc = CustomConfig.getLocationAddWorld(boxJson, "", game.getWorld());
+			Location loc = CustomConfig.getLocationWithWorld(boxJson, "", game.getWorld());
 			String facing = CustomConfig.getString(boxJson, "facing", "");
 			int cost = CustomConfig.getInt(boxJson, "cost", 2000);
 			String boxId = CustomConfig.getString(boxJson, "id", "MISSING");
@@ -86,7 +86,7 @@ public class BoxManager
 
 	public RandomBox getRandomBox(RandomBox exclude)
 	{
-		if(boxes.size() == 0)
+		if(boxes.isEmpty())
 			return null;
 
 		// Just to prevent infinite loop below

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/DoorManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/DoorManager.java
@@ -7,11 +7,15 @@ import com.theprogrammingturkey.comz.config.CustomConfig;
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.features.Door;
 import com.theprogrammingturkey.comz.spawning.SpawnPoint;
+import java.util.Collections;
 import org.bukkit.Location;
 import org.bukkit.block.Sign;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 public class DoorManager
 {
@@ -23,14 +27,10 @@ public class DoorManager
 		this.game = game;
 	}
 
-	public Door getDoorFromSign(Location location)
-	{
-		for(Door door : doors)
-		{
-			for(Sign sign : door.getSigns())
-			{
-				if(sign.getLocation().equals(location))
-				{
+	public @Nullable Door getDoorFromSign(@NotNull Location location) {
+		for (Door door : doors) {
+			for (Location sign : door.getSigns()) {
+				if (sign.equals(location)) {
 					return door;
 				}
 			}
@@ -71,9 +71,9 @@ public class DoorManager
 		return saveJson;
 	}
 
-	public List<Door> getDoors()
+	public @UnmodifiableView List<Door> getDoors()
 	{
-		return doors;
+		return Collections.unmodifiableList(doors);
 	}
 
 	public boolean canSpawnZombieAtPoint(SpawnPoint point)

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/DownedPlayerManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/DownedPlayerManager.java
@@ -2,10 +2,12 @@ package com.theprogrammingturkey.comz.game.managers;
 
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.features.DownedPlayer;
+import java.util.Collections;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.jetbrains.annotations.UnmodifiableView;
 
 public class DownedPlayerManager
 {
@@ -73,8 +75,8 @@ public class DownedPlayerManager
 		downedPlayers.remove(dp);
 	}
 
-	public List<DownedPlayer> getDownedPlayers()
+	public @UnmodifiableView List<DownedPlayer> getDownedPlayers()
 	{
-		return downedPlayers;
+		return Collections.unmodifiableList(downedPlayers);
 	}
 }

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/PerkManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/PerkManager.java
@@ -5,6 +5,7 @@ import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.features.PerkType;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 
+import java.util.Collections;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jetbrains.annotations.UnmodifiableView;
 
 public class PerkManager
 {
@@ -31,9 +33,9 @@ public class PerkManager
 		}
 	}
 
-	public List<PerkType> getPlayersPerks(Player player)
+	public @UnmodifiableView List<PerkType> getPlayersPerks(Player player)
 	{
-		return playersPerks.computeIfAbsent(player, k -> new ArrayList<>());
+		return Collections.unmodifiableList(playersPerks.computeIfAbsent(player, k -> new ArrayList<>()));
 	}
 
 	public boolean hasPerk(Player player, PerkType type)
@@ -43,7 +45,7 @@ public class PerkManager
 
 	public boolean addPerk(Player player, PerkType type)
 	{
-		List<PerkType> playerPerks = getPlayersPerks(player);
+		List<PerkType> playerPerks = playersPerks.computeIfAbsent(player, k -> new ArrayList<>());
 
 		if(playerPerks.contains(type))
 		{

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/PlayerWeaponManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/PlayerWeaponManager.java
@@ -9,12 +9,14 @@ import com.theprogrammingturkey.comz.game.weapons.Weapon;
 import com.theprogrammingturkey.comz.game.weapons.WeaponInstance;
 import com.theprogrammingturkey.comz.game.weapons.WeaponType;
 
+import java.util.Collections;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.jetbrains.annotations.UnmodifiableView;
 
 public class PlayerWeaponManager
 {
@@ -29,9 +31,9 @@ public class PlayerWeaponManager
 	/**
 	 * @return List of guns in the manager
 	 */
-	public List<WeaponInstance> getWeapons()
+	public @UnmodifiableView List<WeaponInstance> getWeapons()
 	{
-		return weapons;
+		return Collections.unmodifiableList(weapons);
 	}
 
 	/**

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/PowerUpManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/PowerUpManager.java
@@ -6,6 +6,7 @@ import com.theprogrammingturkey.comz.config.CustomConfig;
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.GameManager;
 import com.theprogrammingturkey.comz.game.features.PowerUp;
+import java.util.Locale;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
@@ -37,7 +38,8 @@ public class PowerUpManager
 		JsonObject powerUpsJson = powerUpSettings.get("powerups").getAsJsonObject();
 		for(PowerUp powerUp : PowerUp.values())
 			if(powerUp != PowerUp.NONE)
-				powerups.put(powerUp, CustomConfig.getBoolean(powerUpsJson, powerUp.name().toLowerCase(), true));
+				powerups.put(powerUp, CustomConfig.getBoolean(powerUpsJson, powerUp.name().toLowerCase(
+						Locale.ROOT), true));
 	}
 
 	public JsonObject save()
@@ -48,7 +50,7 @@ public class PowerUpManager
 		JsonObject powerUpsJson = new JsonObject();
 		for(PowerUp powerUp : PowerUp.values())
 			if(powerUp != PowerUp.NONE)
-				powerUpsJson.addProperty(powerUp.name().toLowerCase(), powerups.get(powerUp));
+				powerUpsJson.addProperty(powerUp.name().toLowerCase(Locale.ROOT), powerups.get(powerUp));
 
 		saveJson.add("powerups", powerUpsJson);
 
@@ -110,16 +112,14 @@ public class PowerUpManager
 		if(game == null || game.getMode() != Game.ArenaStatus.INGAME)
 			return;
 
-		int chance = (int) (Math.random() * 100);
-		if(chance <= dropChance)
+		int chance = COMZombies.rand.nextInt(100);
+		if(chance < dropChance)
 		{
-			List<PowerUp> availableRewards = powerups.keySet().stream().filter(powerups::get).collect(Collectors.toList());
+			List<PowerUp> availableRewards = powerups.keySet().stream().filter(powerups::get)
+					.filter(powerUp -> !(powerUp == PowerUp.FIRE_SALE && game.boxManager.isMultiBox()))
+					.toList();
 			if(availableRewards.isEmpty())
 				return;
-
-			if(availableRewards.contains(PowerUp.FIRE_SALE))
-				if(game.boxManager.isMultiBox())
-					availableRewards.remove(PowerUp.FIRE_SALE);
 
 			this.dropPowerUp(mob, availableRewards.get(COMZombies.rand.nextInt(availableRewards.size())));
 		}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/TeleporterManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/TeleporterManager.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import com.theprogrammingturkey.comz.config.CustomConfig;
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.GameManager;
+import java.util.Locale;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -31,7 +32,7 @@ public class TeleporterManager
 				continue;
 			JsonObject teleporterJson = teleporterElem.getAsJsonObject();
 
-			Location loc = CustomConfig.getLocationAddWorld(teleporterJson, "", game.getWorld());
+			Location loc = CustomConfig.getLocationWithWorld(teleporterJson, "", game.getWorld());
 			String teleporterID = CustomConfig.getString(teleporterJson, "id", "missing");
 			this.teleporters.put(teleporterID, loc);
 		}
@@ -52,14 +53,14 @@ public class TeleporterManager
 
 	public void saveTeleporterSpot(String teleName, Location to)
 	{
-		teleName = teleName.toLowerCase();
+		teleName = teleName.toLowerCase(Locale.ROOT);
 		teleporters.put(teleName, to);
 		GameManager.INSTANCE.saveAllGames();
 	}
 
 	public void removedTeleporter(String teleName, Player player)
 	{
-		teleName = teleName.toLowerCase();
+		teleName = teleName.toLowerCase(Locale.ROOT);
 		if(teleporters.containsKey(teleName))
 		{
 			teleporters.remove(teleName);

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/WeaponManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/managers/WeaponManager.java
@@ -63,15 +63,15 @@ public class WeaponManager
 			if(weapon instanceof BaseGun && playerWeaponManager.hasGun((BaseGun) weapon))
 				return false;
 			return includePackaPunch || !(weapon instanceof PackAPunchGun);
-		}).collect(Collectors.toList());
+		}).toList();
 		return weaponsToChoose.get(COMZombies.rand.nextInt(weaponsToChoose.size()));
 	}
 
 	public static void listGuns(Player player)
 	{
-		List<BaseGun> guns = weapons.stream().filter(weapon -> weapon instanceof BaseGun).map(weapon -> (BaseGun) weapon).collect(Collectors.toList());
+		List<BaseGun> guns = weapons.stream().filter(weapon -> weapon instanceof BaseGun).map(weapon -> (BaseGun) weapon).toList();
 		CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "---------" + ChatColor.GOLD + "Guns" + ChatColor.RED + "----------");
-		if(guns.size() == 0)
+		if(guns.isEmpty())
 			CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "You have no guns! Make sure COM: Z can read from your " + ChatColor.GOLD + "guns.json");
 
 		WeaponType gunClass = guns.get(0).getWeaponType();

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/AmmoCrateSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/AmmoCrateSign.java
@@ -6,6 +6,7 @@ import com.theprogrammingturkey.comz.game.managers.PlayerWeaponManager;
 import com.theprogrammingturkey.comz.game.weapons.GunInstance;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 import org.bukkit.ChatColor;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
@@ -13,15 +14,15 @@ import org.bukkit.event.block.SignChangeEvent;
 public class AmmoCrateSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
 
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
-		int buyPoints = Integer.parseInt(sign.getLine(2).trim());
+		int buyPoints = Integer.parseInt(((Sign) signBlock.getState()).getLine(2).trim());
 
 		PlayerWeaponManager manager = game.getPlayersWeapons(player);
 		if(manager.isHeldItemWeapon())

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/DoorSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/DoorSign.java
@@ -5,6 +5,7 @@ import com.theprogrammingturkey.comz.economy.PointManager;
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 import org.bukkit.ChatColor;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
@@ -12,14 +13,14 @@ import org.bukkit.event.block.SignChangeEvent;
 public class DoorSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
-		Door door = game.doorManager.getDoorFromSign(sign.getLocation());
+		Door door = game.doorManager.getDoorFromSign(signBlock.getLocation());
 		if(door == null)
 		{
 			CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "An error occured when trying to open this door! Leave the game an contact an admin please.");
@@ -28,7 +29,7 @@ public class DoorSign implements IGameSign
 		{
 			CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "This door is already open!");
 		}
-		else if(PointManager.INSTANCE.getPlayerPoints(player).getPoints() < door.getCost())
+		else if(!door.canOpen(PointManager.INSTANCE.getPlayerPoints(player).getPoints()))
 		{
 			CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "You don't have enough points!");
 		}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/GrenadeSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/GrenadeSign.java
@@ -1,15 +1,13 @@
 package com.theprogrammingturkey.comz.game.signs;
 
-import com.theprogrammingturkey.comz.COMZombies;
 import com.theprogrammingturkey.comz.economy.PointManager;
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.managers.PlayerWeaponManager;
 import com.theprogrammingturkey.comz.game.managers.WeaponManager;
-import com.theprogrammingturkey.comz.game.weapons.BaseGun;
 import com.theprogrammingturkey.comz.game.weapons.Weapon;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 import org.bukkit.ChatColor;
-import org.bukkit.Sound;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
@@ -17,40 +15,33 @@ import org.bukkit.event.block.SignChangeEvent;
 public class GrenadeSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
 
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
-	{
-		String line2 = sign.getLine(2);
+	public void onInteract(Game game, Player player, Block signBlock) {
+		String line2 = ((Sign) signBlock.getState()).getLine(2);
 		int buyPoints = Integer.parseInt(line2);
 		Weapon w = WeaponManager.getWeapon("grenade");
 
 		PlayerWeaponManager manager = game.getPlayersWeapons(player);
 
-
-
-        if(PointManager.INSTANCE.canBuy(player, buyPoints))
-        {
-            if(manager.hasFullGrenades())
-            {
-                CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "You already have grenades!");
-                return;
-            } else {
-                manager.addWeapon(w);
-                CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "Bought grenades!");
-                PointManager.INSTANCE.takePoints(player, buyPoints);
-                PointManager.INSTANCE.notifyPlayer(player);
-            }
-        }
-        else
-        {
-            CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "You don't have enough points!");
-        }
-    
+		if (PointManager.INSTANCE.canBuy(player, buyPoints)) {
+			if (manager.hasFullGrenades()) {
+				CommandUtil.sendMessageToPlayer(player,
+						ChatColor.RED + "" + ChatColor.BOLD + "You already have grenades!");
+      } else {
+				manager.addWeapon(w);
+				CommandUtil.sendMessageToPlayer(player,
+						ChatColor.RED + "" + ChatColor.BOLD + "Bought grenades!");
+				PointManager.INSTANCE.takePoints(player, buyPoints);
+				PointManager.INSTANCE.notifyPlayer(player);
+			}
+		} else {
+			CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "You don't have enough points!");
+		}
 	}
 
 	@Override
@@ -61,11 +52,12 @@ public class GrenadeSign implements IGameSign
 		event.setLine(0, ChatColor.RED + "[Zombies]");
 		event.setLine(1, ChatColor.AQUA + "Grenade");
 
-		String price = thirdLine;
-        if(thirdLine == null || !thirdLine.matches("[0-9]+"))
-            price = "250";
-        else
-            price = thirdLine;
+		String price;
+		if (thirdLine == null || !thirdLine.matches("[0-9]+")) {
+			price = "250";
+		} else {
+			price = thirdLine;
+		}
 		event.setLine(2, price);
 	}
 

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/GunSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/GunSign.java
@@ -9,6 +9,7 @@ import com.theprogrammingturkey.comz.game.weapons.BaseGun;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Sound;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
@@ -16,14 +17,15 @@ import org.bukkit.event.block.SignChangeEvent;
 public class GunSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
 
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
+		final Sign sign = (Sign) signBlock.getState();
 		String line3 = sign.getLine(3);
 		int buyPoints = Integer.parseInt(line3.substring(0, line3.indexOf("/") - 1).trim());
 		int refillPoints = Integer.parseInt(line3.substring(line3.indexOf("/") + 2).trim());

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/IGameSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/IGameSign.java
@@ -1,15 +1,15 @@
 package com.theprogrammingturkey.comz.game.signs;
 
 import com.theprogrammingturkey.comz.game.Game;
-import org.bukkit.block.Sign;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
 
 public interface IGameSign
 {
-	void onBreak(Game game, Player player, Sign sign);
+	void onBreak(Game game, Player player, Block signBlock);
 
-	void onInteract(Game game, Player player, Sign sign);
+	void onInteract(Game game, Player player, Block signBlock);
 
 	void onChange(Game game, Player player, SignChangeEvent event);
 

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/JoinSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/JoinSign.java
@@ -4,8 +4,10 @@ import com.theprogrammingturkey.comz.commands.CommandManager;
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.GameManager;
 import com.theprogrammingturkey.comz.util.CommandUtil;
+import java.util.Objects;
 import org.bukkit.ChatColor;
 import org.bukkit.Sound;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
@@ -13,26 +15,26 @@ import org.bukkit.event.block.SignChangeEvent;
 public class JoinSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
-		game.signManager.removeSign(sign);
+		game.signManager.removeSign(signBlock.getLocation());
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
+		final Sign sign = (Sign) signBlock.getState();
 		game = GameManager.INSTANCE.getGame(sign.getLine(2));
 		if(game != null)
 		{
-			if(!game.signManager.isSign(sign))
-				game.signManager.addSign(sign);
+			if(!game.signManager.isGameSign(sign.getLocation()))
+				game.signManager.addSign(sign.getLocation());
 
 			String[] args = new String[2];
 			args[0] = "join";
 			args[1] = game.getName();
 			player.getLocation().getWorld().playSound(player.getLocation(), Sound.ENTITY_ZOMBIE_AMBIENT, 1, 1);
 			CommandManager.INSTANCE.onRemoteCommand(player, args);
-			game.signManager.updateGame();
 		}
 		else
 		{
@@ -53,8 +55,8 @@ public class JoinSign implements IGameSign
 			event.setLine(3, "");
 			return;
 		}
-		game = GameManager.INSTANCE.getGame(thirdLine);
-		game.signManager.addSign((Sign) event.getBlock().getState());
+		game = Objects.requireNonNull(GameManager.INSTANCE.getGame(thirdLine));
+		game.signManager.addSign(event.getBlock().getLocation());
 	}
 
 	@Override

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/KitSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/KitSign.java
@@ -6,6 +6,7 @@ import com.theprogrammingturkey.comz.kits.KitManager;
 import com.theprogrammingturkey.comz.util.COMZPermission;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 import org.bukkit.ChatColor;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
@@ -13,15 +14,15 @@ import org.bukkit.event.block.SignChangeEvent;
 public class KitSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
 
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
-		Kit kit = KitManager.getKit(ChatColor.stripColor(sign.getLine(2)));
+		Kit kit = KitManager.getKit(ChatColor.stripColor(((Sign) signBlock.getState()).getLine(2)));
 		if(COMZPermission.KIT.hasPerm(player, kit.getName()))
 		{
 			KitManager.addPlayersSelectedKit(player, kit);

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/MysteryBoxSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/MysteryBoxSign.java
@@ -6,6 +6,7 @@ import com.theprogrammingturkey.comz.util.CommandUtil;
 import com.theprogrammingturkey.comz.game.features.RandomBox;
 import org.bukkit.ChatColor;
 import org.bukkit.Sound;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
 import org.bukkit.block.data.Directional;
@@ -14,23 +15,23 @@ import org.bukkit.event.block.SignChangeEvent;
 
 public class MysteryBoxSign implements IGameSign
 {
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
-		RandomBox box = game.boxManager.getBox(sign.getLocation());
+		RandomBox box = game.boxManager.getBox(signBlock.getLocation());
 		if(box != null)
 			game.boxManager.removeBox(player, box);
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
-		RandomBox box = game.boxManager.getBox(sign.getLocation());
+		RandomBox box = game.boxManager.getBox(signBlock.getLocation());
 		if(box == null)
 			return;
 
 		if(box.canActivate())
 		{
-			int points = Integer.parseInt(sign.getLine(2));
+			int points = Integer.parseInt(((Sign) signBlock.getState()).getLine(2));
 			if(game.isFireSale())
 				points = 10;
 

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/PackAPunchSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/PackAPunchSign.java
@@ -8,6 +8,7 @@ import com.theprogrammingturkey.comz.game.managers.PlayerWeaponManager;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Sound;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
@@ -15,13 +16,13 @@ import org.bukkit.event.block.SignChangeEvent;
 public class PackAPunchSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
 
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
 		if(game.hasPower() && !game.isPowered())
 		{
@@ -39,7 +40,7 @@ public class PackAPunchSign implements IGameSign
 
 		GunInstance gun = manager.getGun(player.getInventory().getHeldItemSlot());
 
-		int cost = Integer.parseInt(sign.getLine(2));
+		int cost = Integer.parseInt(((Sign) signBlock.getState()).getLine(2));
 		if(PointManager.INSTANCE.canBuy(player, cost))
 		{
 			if(gun.isPackOfPunched())

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/PerkMachineSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/PerkMachineSign.java
@@ -5,8 +5,10 @@ import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.features.PerkType;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 import com.theprogrammingturkey.comz.listeners.customEvents.PlayerPerkPurchaseEvent;
+import java.util.Locale;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
@@ -16,14 +18,15 @@ import org.bukkit.potion.PotionEffectType;
 public class PerkMachineSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
 
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
+		final Sign sign = (Sign) signBlock.getState();
 		String perkName = sign.getLine(2);
 		PerkType perk = PerkType.getPerkType(perkName);
 		if(game.hasPower() && !game.isPowered())
@@ -73,7 +76,7 @@ public class PerkMachineSign implements IGameSign
 			return;
 
 		Bukkit.getPluginManager().callEvent(new PlayerPerkPurchaseEvent(player, perk));
-		CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "You now have " + perk.toString().toLowerCase() + "!");
+		CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "You now have " + perk.toString().toLowerCase(Locale.ROOT) + "!");
 		int slot = game.perkManager.getAvailablePerkSlot(player);
 		perk.initialEffect(player, perk, slot);
 		if(perk.equals(PerkType.STAMIN_UP))
@@ -112,7 +115,7 @@ public class PerkMachineSign implements IGameSign
 
 			sign.setLine(0, ChatColor.RED + "[Zombies]");
 			sign.setLine(1, ChatColor.AQUA + "Perk Machine");
-			sign.setLine(2, type.toString().toLowerCase());
+			sign.setLine(2, type.toString().toLowerCase(Locale.ROOT));
 			sign.setLine(3, Integer.toString(cost));
 		}
 	}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/PowerSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/PowerSign.java
@@ -3,20 +3,20 @@ package com.theprogrammingturkey.comz.game.signs;
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 import org.bukkit.ChatColor;
-import org.bukkit.block.Sign;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
 
 public class PowerSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
 
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
 		if(game.hasPower())
 		{

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/SpectateSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/SpectateSign.java
@@ -4,6 +4,7 @@ import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.GameManager;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 import org.bukkit.ChatColor;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
@@ -11,15 +12,15 @@ import org.bukkit.event.block.SignChangeEvent;
 public class SpectateSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
 
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
-		game = GameManager.INSTANCE.getGame(sign.getLine(3));
+		game = GameManager.INSTANCE.getGame(((Sign) signBlock.getState()).getLine(3));
 		if(game == null)
 		{
 			CommandUtil.sendMessageToPlayer(player, ChatColor.DARK_RED + "Invalid Arena!");

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/TeleporterSign.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/signs/TeleporterSign.java
@@ -7,8 +7,10 @@ import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.GameManager;
 import com.theprogrammingturkey.comz.game.features.PerkType;
 import com.theprogrammingturkey.comz.util.CommandUtil;
+import java.util.Locale;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;
@@ -18,17 +20,18 @@ import org.bukkit.potion.PotionEffectType;
 public class TeleporterSign implements IGameSign
 {
 	@Override
-	public void onBreak(Game game, Player player, Sign sign)
+	public void onBreak(Game game, Player player, Block signBlock)
 	{
 
 	}
 
 	@Override
-	public void onInteract(Game game, Player player, Sign sign)
+	public void onInteract(Game game, Player player, Block signBlock)
 	{
+		final Sign sign = (Sign) signBlock.getState();
 		if(GameManager.INSTANCE.isPlayerInGame(player))
 		{
-			String teleporterName = sign.getLine(2).toLowerCase();
+			String teleporterName = sign.getLine(2).toLowerCase(Locale.ROOT);
 			if(game.teleporterManager.getTeleporters().containsKey(teleporterName))
 			{
 				if(game.hasPower() && !game.isPowered())
@@ -45,8 +48,11 @@ public class TeleporterSign implements IGameSign
 					player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 30, 30));
 
 					for(int i = 0; i < 50; i++)
-						for(Player pl : Bukkit.getOnlinePlayers())
-							COMZombies.nmsUtil.sendParticleToPlayer(NMSParticleType.WITCH, pl, player.getLocation(), (float) (Math.random()), (float) (Math.random()), (float) (Math.random()), 1, 1);
+						for (Player pl : Bukkit.getOnlinePlayers()) {
+							COMZombies.nmsUtil.sendParticleToPlayer(NMSParticleType.WITCH, pl,
+									player.getLocation(), COMZombies.rand.nextFloat(), COMZombies.rand.nextFloat(),
+									COMZombies.rand.nextFloat(), 1, 1);
+						}
 
 					PointManager.INSTANCE.takePoints(player, points);
 					PointManager.INSTANCE.notifyPlayer(player);
@@ -70,7 +76,7 @@ public class TeleporterSign implements IGameSign
 		if(game.teleporterManager.getTeleporters().containsKey(thirdLine))
 		{
 			String line3 = sign.getLine(3);
-			if(line3 == null || line3.equals(""))
+			if(line3 == null || line3.isEmpty())
 			{
 				sign.setLine(0, ChatColor.RED + "[Zombies]");
 				sign.setLine(1, ChatColor.AQUA + "Teleporter");

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/weapons/GunInstance.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/weapons/GunInstance.java
@@ -6,6 +6,7 @@ import com.theprogrammingturkey.comz.COMZombies;
 import com.theprogrammingturkey.comz.config.ConfigManager;
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.GameManager;
+import java.util.Objects;
 import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.World;
@@ -103,8 +104,7 @@ public class GunInstance extends WeaponInstance
 	}
 
 	/**
-	 * Used to reload this current weapon. If the player contained in this gun
-	 * has speed cola, reload times speed up.
+	 * Used to reload this current weapon.
 	 */
 	public void reload()
 	{
@@ -117,10 +117,7 @@ public class GunInstance extends WeaponInstance
 
 			isReloading = true;
 			Game game = GameManager.INSTANCE.getGame(player);
-			final int reloadTime;
-			if(game.perkManager.hasPerk(player, PerkType.SPEED_COLA))
-				reloadTime = (ConfigManager.getMainConfig().reloadTime) / 2;
-			else reloadTime = ConfigManager.getMainConfig().reloadTime;
+			final int reloadTime = ConfigManager.getMainConfig().reloadTime;
 			COMZombies.scheduleTask(reloadTime * 20L, () ->
 			{
 
@@ -184,7 +181,8 @@ public class GunInstance extends WeaponInstance
 
 	/**
 	 * Called when the gun was shot, decrements total ammo count and reloads if
-	 * the bullet shot was the last in the clip.
+	 * the bullet shot was the last in the clip. If the player contained in this gun
+	 * has speed cola, fire delay speeds up.
 	 */
 	public boolean wasShot()
 	{
@@ -213,13 +211,17 @@ public class GunInstance extends WeaponInstance
 		updateWeapon();
 		canFire = false;
 
-		COMZombies.scheduleTask(this.gun.fireDelay, () -> canFire = true);
+		Game game = Objects.requireNonNull(GameManager.INSTANCE.getGame(player));
+
+		COMZombies.scheduleTask(
+				game.perkManager.hasPerk(player, PerkType.SPEED_COLA) ? (long) (this.gun.fireDelay / 1.25)
+						: this.gun.fireDelay, () -> canFire = true);
 		return true;
 	}
 
 	public double getAdjust()
 	{
-		return (Math.random() - 0.5) * 1.5;
+		return COMZombies.rand.nextDouble(1.5) - 0.75;
 	}
 
 	/**

--- a/Core/src/main/java/com/theprogrammingturkey/comz/game/weapons/WeaponType.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/game/weapons/WeaponType.java
@@ -29,7 +29,7 @@ public enum WeaponType
 	public static WeaponType getWeapon(String name)
 	{
 		for(WeaponType type : values())
-			if(type.toString().toLowerCase().equalsIgnoreCase(name))
+			if(type.toString().equalsIgnoreCase(name))
 				return type;
 		return SPECIAL;
 	}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/kits/Kit.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/kits/Kit.java
@@ -146,7 +146,7 @@ public class Kit
 	{
 		for(RoundReward roundReward : roundRewards)
 		{
-			if(roundReward.getRoundEnd() == roundEnd)
+			if(roundReward.roundEnd() == roundEnd)
 			{
 				if(!GameManager.INSTANCE.isPlayerInGame(player) && !COMZPermission.KIT.hasPerm(player, name))
 					return;
@@ -156,13 +156,13 @@ public class Kit
 
 				PlayerWeaponManager manager = game.getPlayersWeapons(player);
 
-				for(Weapon weapon : roundReward.getWeapons())
+				for(Weapon weapon : roundReward.weapons())
 					manager.addWeapon(weapon);
 
-				for(PerkType perk : roundReward.getPerks())
+				for(PerkType perk : roundReward.perks())
 					PerkManager.givePerk(game, player, perk);
 
-				PointManager.INSTANCE.addPoints(player, roundReward.getPoints() - 500);
+				PointManager.INSTANCE.addPoints(player, roundReward.points() - 500);
 				game.scoreboard.update();
 				player.updateInventory();
 			}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/kits/RoundReward.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/kits/RoundReward.java
@@ -4,39 +4,9 @@ import com.theprogrammingturkey.comz.game.features.PerkType;
 import com.theprogrammingturkey.comz.game.weapons.Weapon;
 
 import java.util.List;
+import org.jetbrains.annotations.UnmodifiableView;
 
-public class RoundReward
-{
-	private final int roundEnd;
-	private final int points;
-	private final List<Weapon> weapons;
-	private final List<PerkType> perks;
+public record RoundReward(int roundEnd, int points, @UnmodifiableView List<Weapon> weapons,
+													@UnmodifiableView List<PerkType> perks) {
 
-	public RoundReward(int roundEnd, int points, List<Weapon> weapons, List<PerkType> perks)
-	{
-		this.roundEnd = roundEnd;
-		this.points = points;
-		this.weapons = weapons;
-		this.perks = perks;
-	}
-
-	public int getRoundEnd()
-	{
-		return roundEnd;
-	}
-
-	public int getPoints()
-	{
-		return points;
-	}
-
-	public List<Weapon> getWeapons()
-	{
-		return weapons;
-	}
-
-	public List<PerkType> getPerks()
-	{
-		return perks;
-	}
 }

--- a/Core/src/main/java/com/theprogrammingturkey/comz/leaderboards/PlayerStats.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/leaderboards/PlayerStats.java
@@ -51,25 +51,16 @@ public class PlayerStats
 
 	public int getStat(StatsCategory cat)
 	{
-		switch(cat)
-		{
-			case KILLS:
-				return kills;
-			case REVIVES:
-				return revives;
-			case DEATHS:
-				return deaths;
-			case DOWNS:
-				return downs;
-			case GAMES_PLAYED:
-				return gamesPlayed;
-			case HIGHEST_ROUND:
-				return highestRound;
-			case MOST_POINTS:
-				return mostPoints;
-			default:
-				return 0;
-		}
+    return switch (cat) {
+      case KILLS -> kills;
+      case REVIVES -> revives;
+      case DEATHS -> deaths;
+      case DOWNS -> downs;
+      case GAMES_PLAYED -> gamesPlayed;
+      case HIGHEST_ROUND -> highestRound;
+      case MOST_POINTS -> mostPoints;
+      default -> 0;
+    };
 	}
 
 	public int getKills()

--- a/Core/src/main/java/com/theprogrammingturkey/comz/listeners/BarrierRepairListener.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/listeners/BarrierRepairListener.java
@@ -1,0 +1,99 @@
+package com.theprogrammingturkey.comz.listeners;
+
+import com.theprogrammingturkey.comz.COMZombies;
+import com.theprogrammingturkey.comz.game.Game;
+import com.theprogrammingturkey.comz.game.GameManager;
+import com.theprogrammingturkey.comz.game.features.Barrier;
+import com.theprogrammingturkey.comz.util.BlockUtils;
+import com.theprogrammingturkey.comz.util.CommandUtil;
+import java.util.HashMap;
+import java.util.Objects;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerToggleSneakEvent;
+import org.bukkit.util.BoundingBox;
+
+public class BarrierRepairListener implements Listener {
+
+  private final HashMap<Player, Integer> repairTaskIds = new HashMap<>();
+
+  @EventHandler
+  public void onPlayerToggleSneak(PlayerToggleSneakEvent event) {
+    Player player = event.getPlayer();
+    if (event.isSneaking()) {
+      if (repairTaskIds.containsKey(player)) {
+        return;
+      }
+
+      Game game = GameManager.INSTANCE.getGame(player);
+      if (game == null) {
+        return;
+      }
+      for (Barrier barrier : game.barrierManager.getBarriers()) {
+        BlockFace face = barrier.getSignFacing();
+        Location signLocation = barrier.getRepairLoc();
+        Location boundLocation1 = signLocation.clone()
+            .add(face.getModZ(), 2, face.getModX()) // add a vector perpendicular to the sign face
+            .add(Math.abs(face.getModX()), 0, Math.abs(face.getModZ())); // compensate length of one block on the direction of sign block face
+        Location boundLocation2 = signLocation.clone()
+            .subtract(face.getModZ(), 3, face.getModX()); // TODO: incorrect subtract
+
+        if (BoundingBox.of(boundLocation1, boundLocation2).overlaps(player.getBoundingBox())) {
+          repairTaskIds.put(player, COMZombies.scheduleTask(30, 30, () -> {
+            if (barrier.getStage() != -1) {
+              boolean repaired = barrier.repair(player);
+
+              if (repaired) {
+                Objects.requireNonNull(signLocation.getWorld())
+                    .playSound(signLocation, Sound.BLOCK_ANVIL_LAND, 1, 4);
+              } else {
+                Objects.requireNonNull(signLocation.getWorld())
+                    .playSound(signLocation, Sound.ENTITY_ZOMBIE_ATTACK_WOODEN_DOOR, 1, 1.5f);
+              }
+            }
+          }));
+
+          break;
+        }
+      }
+    } else {
+      Integer taskId = repairTaskIds.get(player);
+      if (taskId != null) {
+        repairTaskIds.remove(player);
+        Bukkit.getScheduler().cancelTask(taskId);
+      }
+    }
+  }
+
+  @EventHandler(priority = EventPriority.HIGH)
+  public void onBlockBreakEvent(BlockBreakEvent event) {
+    if (BlockUtils.isBarrierRepairSign(event.getBlock())) {
+      Player player = event.getPlayer();
+      if (GameManager.INSTANCE.isPlayerInGame(player)) {
+        Game game = GameManager.INSTANCE.getGame(player);
+        Sign sign = (Sign) event.getBlock().getState();
+        Barrier b = game.barrierManager.getBarrierFromRepair(sign.getLocation());
+        if (b != null) {
+          boolean repaired = b.repair(player);
+          if (repaired) {
+            Objects.requireNonNull(event.getBlock().getWorld())
+                .playSound(event.getBlock().getLocation(), Sound.BLOCK_ANVIL_LAND, 1, 4);
+          }
+          event.setCancelled(true);
+        } else {
+          CommandUtil.sendMessageToPlayer(player,
+              "Congrats! You broke the plugin! JK its all fixed now.");
+          BlockUtils.setBlockToAir(event.getBlock());
+        }
+      }
+    }
+  }
+}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/listeners/EntityListener.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/listeners/EntityListener.java
@@ -12,6 +12,7 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Zombie;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -70,6 +71,10 @@ public class EntityListener implements Listener
 					}
 
 					float damage = (float) ConfigManager.getMainConfig().zombieDamage;
+
+					if (e.getEntity() instanceof Zombie && ((Zombie) e.getEntity()).isAdult()) {
+						damage /= 3.5f;
+					}
 
 					if(game.perkManager.getPlayersPerks(player).contains(PerkType.JUGGERNOG))
 						damage = damage / (float) ConfigManager.getMainConfig().juggernogHealth;

--- a/Core/src/main/java/com/theprogrammingturkey/comz/listeners/OnPreCommandEvent.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/listeners/OnPreCommandEvent.java
@@ -1,5 +1,6 @@
 package com.theprogrammingturkey.comz.listeners;
 
+import com.theprogrammingturkey.comz.util.COMZPermission;
 import com.theprogrammingturkey.comz.util.CommandUtil;
 import com.theprogrammingturkey.comz.game.GameManager;
 import org.bukkit.ChatColor;
@@ -24,7 +25,7 @@ public class OnPreCommandEvent implements Listener
 			{
 				return;
 			}
-			if(GameManager.INSTANCE.isPlayerInGame(player))
+			if(GameManager.INSTANCE.isPlayerInGame(player) && !COMZPermission.doesPlayerHaveAdminPerms(player))
 			{
 				CommandUtil.sendMessageToPlayer(player, ChatColor.RED + "" + ChatColor.BOLD + "You are not allowed to use commands in game!");
 				event.setCancelled(true);

--- a/Core/src/main/java/com/theprogrammingturkey/comz/listeners/SignListener.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/listeners/SignListener.java
@@ -3,10 +3,11 @@ package com.theprogrammingturkey.comz.listeners;
 import com.theprogrammingturkey.comz.COMZombies;
 import com.theprogrammingturkey.comz.game.Game;
 import com.theprogrammingturkey.comz.game.GameManager;
-import com.theprogrammingturkey.comz.game.features.Barrier;
 import com.theprogrammingturkey.comz.game.signs.*;
 import com.theprogrammingturkey.comz.util.BlockUtils;
+import com.theprogrammingturkey.comz.util.COMZPermission;
 import com.theprogrammingturkey.comz.util.CommandUtil;
+import java.util.Locale;
 import org.bukkit.ChatColor;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
@@ -20,6 +21,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
 
 public class SignListener implements Listener
 {
@@ -72,18 +74,12 @@ public class SignListener implements Listener
 		GAME_SIGNS.put("grenade", grenade);
 	}
 
-	@EventHandler(priority = EventPriority.HIGHEST)
+	@EventHandler(priority = EventPriority.HIGH)
 	public void onBlockBreakEvent(BlockBreakEvent event)
 	{
-		if(!BlockUtils.isSign(event.getBlock().getType()))
-			return;
-
-		Sign sign = (Sign) event.getBlock().getState();
-
-		String lineOne = ChatColor.stripColor(sign.getLine(0));
-		String lineTwo = ChatColor.stripColor(sign.getLine(1));
-		if(lineOne.equalsIgnoreCase("[Zombies]"))
+		if(BlockUtils.isZombiesSign(event.getBlock()))
 		{
+			final Sign sign = (Sign) event.getBlock().getState();
 			Game game = GameManager.INSTANCE.getGame(sign.getLocation());
 			if(game != null && game.getMode() != Game.ArenaStatus.DISABLED)
 			{
@@ -91,60 +87,37 @@ public class SignListener implements Listener
 				return;
 			}
 
-			IGameSign signLogic = GAME_SIGNS.get(lineTwo.toLowerCase());
+			String lineTwo = ChatColor.stripColor(sign.getLine(1));
+			IGameSign signLogic = GAME_SIGNS.get(lineTwo.toLowerCase(Locale.ROOT));
 			if(signLogic != null && (game != null || !signLogic.requiresGame()))
-				signLogic.onBreak(game, event.getPlayer(), sign);
-		}
-		else if(lineOne.equalsIgnoreCase("[BarrierRepair]"))
-		{
-			Player player = event.getPlayer();
-			if(GameManager.INSTANCE.isPlayerInGame(player))
-			{
-				Game game = GameManager.INSTANCE.getGame(player);
-				Barrier b = game.barrierManager.getBarrierFromRepair(sign.getLocation());
-				if(b != null)
-				{
-					b.repair(player);
-					event.setCancelled(true);
-					sign.update();
-				}
-				else
-				{
-					CommandUtil.sendMessageToPlayer(player, "Congrats! You broke the plugin! JK its all fixed now.");
-					BlockUtils.setBlockToAir(event.getBlock());
-				}
-			}
+				signLogic.onBreak(game, event.getPlayer(), event.getBlock());
 		}
 	}
 
 	@EventHandler
-	public void RightClickSign(PlayerInteractEvent event)
+	public void onPlayerInteractWithBlock(@NotNull PlayerInteractEvent event)
 	{
 		if(event.getClickedBlock() == null)
 			return;
 
 		COMZombies plugin = COMZombies.getPlugin();
 
-		if(BlockUtils.isSign(event.getClickedBlock().getType()))
+		if(BlockUtils.isSign(event.getClickedBlock().getBlockData()))
 		{
-			Sign sign = (Sign) event.getClickedBlock().getState();
-			Player player = event.getPlayer();
+			final Sign sign = (Sign) event.getClickedBlock().getState();
+			final Player player = event.getPlayer();
 
 			if (GameManager.INSTANCE.isPlayerInGame(player)) {
-				String lineOne = ChatColor.stripColor(sign.getLine(0));
-				// We don't want to cancel the event if this case so that barrier signs can work
-				if(event.getAction() != Action.LEFT_CLICK_BLOCK || !lineOne.equalsIgnoreCase("[BarrierRepair]"))
-				{
-					sign.setEditable(false);
-					sign.update();
+				sign.setEditable(false);
+				sign.update();
+				if (!BlockUtils.isBarrierRepairSign(event.getClickedBlock())) {
 					event.setCancelled(true);
 				}
 			}
 
 			if(event.getAction() == Action.RIGHT_CLICK_BLOCK && player.isSneaking() && player.isOp())
 			{
-				String Line1 = ChatColor.stripColor(sign.getLine(0));
-				if(!plugin.isEditingASign.containsKey(player) && Line1.equalsIgnoreCase("[Zombies]") && !GameManager.INSTANCE.isPlayerInGame(player))
+				if(!plugin.isEditingASign.containsKey(player) && BlockUtils.isZombiesSign(event.getClickedBlock()) && !GameManager.INSTANCE.isPlayerInGame(player))
 				{
 					plugin.isEditingASign.put(player, sign);
 					CommandUtil.sendMessageToPlayer(player, "You are now editing a sign!");
@@ -152,18 +125,17 @@ public class SignListener implements Listener
 				}
 			}
 
-			String lineOne = ChatColor.stripColor(sign.getLine(0));
-			String lineTwo = ChatColor.stripColor(sign.getLine(1));
-			if(lineOne.equalsIgnoreCase("[Zombies]"))
+			if(BlockUtils.isZombiesSign(event.getClickedBlock()))
 			{
 				Game game = GameManager.INSTANCE.getGame(sign.getLocation());
-				IGameSign signLogic = GAME_SIGNS.get(lineTwo.toLowerCase());
+				String lineTwo = ChatColor.stripColor(sign.getLine(1));
+				IGameSign signLogic = GAME_SIGNS.get(lineTwo.toLowerCase(Locale.ROOT));
 				if(signLogic != null && (game != null || !signLogic.requiresGame()))
 				{
 					if(game != null && signLogic.requiresGame() && game.getMode() != Game.ArenaStatus.INGAME)
 						return;
 
-					signLogic.onInteract(game, player, sign);
+					signLogic.onInteract(game, player, event.getClickedBlock());
 					event.setCancelled(true);
 				}
 			}
@@ -171,33 +143,42 @@ public class SignListener implements Listener
 	}
 
 	@EventHandler
-	public void eventSignChanged(SignChangeEvent event)
-	{
-		if(!BlockUtils.isSign(event.getBlock().getType()))
+	public void eventSignChanged(@NotNull SignChangeEvent event) {
+		if (!BlockUtils.isSign(event.getBlock())) {
+			throw new IllegalStateException("eventSignChanged is invoked with a non-sign block");
+		}
+
+		if (GameManager.INSTANCE.isPlayerInGame(event.getPlayer()) || (
+				GameManager.INSTANCE.isLocationInGame(event.getBlock().getLocation())
+						&& !COMZPermission.doesPlayerHaveAdminPerms(event.getPlayer()))) {
+			event.setCancelled(true);
 			return;
-		String lineOne = ChatColor.stripColor(event.getLine(0));
-		String lineTwo = ChatColor.stripColor(event.getLine(1));
-		if(lineOne != null && lineOne.equalsIgnoreCase("[Zombies]") && lineTwo != null)
-		{
-			Game game = GameManager.INSTANCE.getGame(event.getBlock().getLocation());
-			IGameSign signLogic = GAME_SIGNS.get(lineTwo.toLowerCase());
-			if(signLogic != null && (game != null || !signLogic.requiresGame()))
-			{
-				signLogic.onChange(game, event.getPlayer(), event);
+		}
+
+		if (BlockUtils.isZombiesSign(event.getBlock())) {
+			String lineTwo = ChatColor.stripColor(event.getLine(1));
+			if (lineTwo == null) {
+				return;
 			}
-			else if(signLogic == null)
-			{
+
+			IGameSign signLogic = GAME_SIGNS.get(lineTwo.toLowerCase(Locale.ROOT));
+			if (signLogic != null) {
+				Game game = null;
+				if (signLogic.requiresGame()) {
+					game = GameManager.INSTANCE.getGame(event.getBlock().getLocation());
+				}
+				if (game == null) {
+					event.setLine(0, ChatColor.RED + String.valueOf(ChatColor.BOLD) + "Sign is");
+					event.setLine(1, ChatColor.RED + String.valueOf(ChatColor.BOLD) + "not in");
+					event.setLine(2, ChatColor.RED + String.valueOf(ChatColor.BOLD) + "an arena!");
+					event.setLine(3, "");
+					return;
+				}
+				signLogic.onChange(game, event.getPlayer(), event);
+			} else {
 				event.setLine(0, ChatColor.RED + String.valueOf(ChatColor.BOLD) + lineTwo);
 				event.setLine(1, ChatColor.RED + String.valueOf(ChatColor.BOLD) + "is not a");
 				event.setLine(2, ChatColor.RED + String.valueOf(ChatColor.BOLD) + "valid sign");
-				event.setLine(3, "");
-
-			}
-			else
-			{
-				event.setLine(0, ChatColor.RED + String.valueOf(ChatColor.BOLD) + "Sign is");
-				event.setLine(1, ChatColor.RED + String.valueOf(ChatColor.BOLD) + "not in");
-				event.setLine(2, ChatColor.RED + String.valueOf(ChatColor.BOLD) + "an arena!");
 				event.setLine(3, "");
 			}
 		}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/listeners/customEvents/GameStartEvent.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/listeners/customEvents/GameStartEvent.java
@@ -8,6 +8,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 import javax.annotation.Nonnull;
+import org.jetbrains.annotations.UnmodifiableView;
 
 public class GameStartEvent extends Event
 {
@@ -20,7 +21,7 @@ public class GameStartEvent extends Event
 		this.game = game;
 	}
 
-	public List<Player> getInGamePlayers()
+	public @UnmodifiableView List<Player> getInGamePlayers()
 	{
 		return game.getPlayersInGame();
 	}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/spawning/RoundSpawner.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/spawning/RoundSpawner.java
@@ -4,9 +4,6 @@ import com.theprogrammingturkey.comz.game.Game;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
-
-import java.util.List;
 
 public abstract class RoundSpawner
 {

--- a/Core/src/main/java/com/theprogrammingturkey/comz/spawning/ZombieSpawner.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/spawning/ZombieSpawner.java
@@ -21,14 +21,20 @@ public class ZombieSpawner extends RoundSpawner
 			if(zomb.getEquipment() != null)
 				zomb.getEquipment().clear();
 		});
-		zomb.setBaby(false);
+		if (!zomb.isAdult()) {
+			if (COMZombies.rand.nextInt(4) != 0) {
+				zomb.setAdult();
+			} else {
+				setSpeed(zomb, (float) 2 / 3);
+			}
+		}
 		setFollowDistance(zomb, 512);
 
 		float strength = ((wave * 100f) + 50) / 50f;
 		setMaxHealth(zomb, strength);
 		zomb.setHealth(strength);
 
-		if(game.getWave() > 4 && COMZombies.rand.nextInt(100) < 20 + (15 * (game.getWave() - 5)))
+		if(game.getWave() > 4 && COMZombies.rand.nextInt(10) < 2 + (15 * (game.getWave() - 5)))
 			setSpeed(zomb, 1.25f);
 
 		Barrier b = game.barrierManager.getBarrier(loc);

--- a/Core/src/main/java/com/theprogrammingturkey/comz/util/BlockUtils.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/util/BlockUtils.java
@@ -1,5 +1,7 @@
 package com.theprogrammingturkey.comz.util;
 
+import java.util.List;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -7,32 +9,51 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.MultipleFacing;
-import org.bukkit.block.data.type.Sign;
 import org.bukkit.block.data.type.WallSign;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BlockUtils
 {
-	public static boolean isWallSign(Material mat)
+	public static boolean isWallSign(@Nullable BlockData data)
 	{
-		return mat.data == WallSign.class;
+		return data instanceof WallSign;
 	}
 
-	public static boolean isStandingSign(Material mat)
+	public static boolean isStandingSign(@Nullable BlockData data)
 	{
-		return mat.data == Sign.class;
+		return data instanceof org.bukkit.block.data.type.Sign;
 	}
 
-	public static boolean isSign(Material mat)
+	public static boolean isSign(@Nullable BlockData data)
 	{
-		return isStandingSign(mat) || isWallSign(mat);
+		return isStandingSign(data) || isWallSign(data);
 	}
 
-	public static Material getMaterialFromKey(String key)
+	public static boolean isSign(@Nullable Block block)
+	{
+		return block != null && isSign(block.getBlockData());
+	}
+
+	public static boolean isZombiesSign(@Nullable Block block) {
+		return block != null && isSign(block.getBlockData()) &&
+				ChatColor.stripColor(
+						((org.bukkit.block.Sign) block.getState()).getLine(0)
+				).equalsIgnoreCase("[Zombies]");
+	}
+
+	public static boolean isBarrierRepairSign(@Nullable Block block) {
+		return block != null && isSign(block.getBlockData()) && ChatColor.stripColor(
+				((org.bukkit.block.Sign) block.getState()).getLine(0)
+		).equalsIgnoreCase("[BarrierRepair]");
+	}
+
+	public static Material getMaterialFromKey(@NotNull String key)
 	{
 		return getMaterialFromKey(NamespacedKey.minecraft(key));
 	}
 
-	public static Material getMaterialFromKey(NamespacedKey key)
+	public static Material getMaterialFromKey(@NotNull NamespacedKey key)
 	{
 		for(Material mat : Material.values())
 			if(mat.getKey().equals(key))
@@ -40,7 +61,7 @@ public class BlockUtils
 		return Material.IRON_BARS;
 	}
 
-	public static void setBlockTypeHelper(Block block, Material type)
+	public static void setBlockTypeHelper(@NotNull Block block, @NotNull Material type)
 	{
 		block.setType(type);
 		BlockData data = block.getBlockData();
@@ -56,13 +77,34 @@ public class BlockUtils
 		}
 	}
 
-	public static void setBlockToAir(Location location)
+	public static void setBlockToAir(@NotNull Location location)
 	{
 		setBlockToAir(location.getBlock());
 	}
 
-	public static void setBlockToAir(Block block)
+	public static void setBlockToAir(@NotNull Block block)
 	{
 		block.setType(Material.AIR);
+	}
+
+	public static int compareBlockLocation(@NotNull Block block1, @NotNull Block block2) {
+		return compareLocation(block1.getLocation(), block2.getLocation());
+	}
+
+	public static int compareLocation(@NotNull Location location1, @NotNull Location location2) {
+		location1.checkFinite();
+		location2.checkFinite();
+
+		if (location1.getY() != location2.getY()) {
+			return Double.compare(location1.getY(), location2.getY());
+		} else if (location1.getZ() != location2.getZ()) {
+			return Double.compare(location1.getZ(), location2.getZ());
+		} else {
+			return Double.compare(location1.getX(), location2.getX());
+		}
+	}
+
+	public static @NotNull List<Location> sortAndDistinctLocations(@NotNull List<Location> locations) {
+		return locations.stream().sorted(BlockUtils::compareLocation).distinct().toList();
 	}
 }

--- a/Core/src/main/java/com/theprogrammingturkey/comz/util/PlaceholderHook.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/util/PlaceholderHook.java
@@ -137,45 +137,29 @@ public class PlaceholderHook extends PlaceholderExpansion
 
 	private String getStatFromString(String toGet, PlayerStats stats)
 	{
-		switch(toGet)
-		{
-			case "kills":
-				return String.valueOf(stats.getKills());
-			case "revives":
-				return String.valueOf(stats.getRevives());
-			case "deaths":
-				return String.valueOf(stats.getDeaths());
-			case "downs":
-				return String.valueOf(stats.getDowns());
-			case "gamesPlayed":
-				return String.valueOf(stats.getGamesPlayed());
-			case "highestRound":
-				return String.valueOf(stats.getHighestRound());
-			case "mostPoints":
-				return String.valueOf(stats.getMostPoints());
-		}
-		return "";
-	}
+    return switch (toGet) {
+      case "kills" -> String.valueOf(stats.getKills());
+      case "revives" -> String.valueOf(stats.getRevives());
+      case "deaths" -> String.valueOf(stats.getDeaths());
+      case "downs" -> String.valueOf(stats.getDowns());
+      case "gamesPlayed" -> String.valueOf(stats.getGamesPlayed());
+      case "highestRound" -> String.valueOf(stats.getHighestRound());
+      case "mostPoints" -> String.valueOf(stats.getMostPoints());
+      default -> "";
+    };
+  }
 
 	private StatsCategory getStatEnumFromString(String toGet)
 	{
-		switch(toGet)
-		{
-			case "kills":
-				return StatsCategory.KILLS;
-			case "revives":
-				return StatsCategory.REVIVES;
-			case "deaths":
-				return StatsCategory.DEATHS;
-			case "downs":
-				return StatsCategory.DOWNS;
-			case "gamesPlayed":
-				return StatsCategory.GAMES_PLAYED;
-			case "highestRound":
-				return StatsCategory.HIGHEST_ROUND;
-			case "mostPoints":
-				return StatsCategory.MOST_POINTS;
-		}
-		return null;
-	}
+    return switch (toGet) {
+      case "kills" -> StatsCategory.KILLS;
+      case "revives" -> StatsCategory.REVIVES;
+      case "deaths" -> StatsCategory.DEATHS;
+      case "downs" -> StatsCategory.DOWNS;
+      case "gamesPlayed" -> StatsCategory.GAMES_PLAYED;
+      case "highestRound" -> StatsCategory.HIGHEST_ROUND;
+      case "mostPoints" -> StatsCategory.MOST_POINTS;
+      default -> null;
+    };
+  }
 }

--- a/Core/src/main/resources/paper-plugin.yml
+++ b/Core/src/main/resources/paper-plugin.yml
@@ -1,0 +1,13 @@
+name: COM_Zombies
+version: @version@
+main: com.theprogrammingturkey.comz.COMZombies
+description: 'Call of Minecraft: Zombies'
+api-version: '1.19'
+dependencies:
+  server:
+    Vault:
+      load: BEFORE
+      required: false
+    PlaceholderAPI:
+      load: BEFORE
+      required: false

--- a/Core/src/main/resources/plugin.yml
+++ b/Core/src/main/resources/plugin.yml
@@ -5,8 +5,4 @@ version: @version@
 authors: [TurkeyDev]
 api-version: '1.14'
 load: POSTWORLD
-softdepend: [Multiverse-Core, Vault, PlaceholderAPI, My_Worlds]
-commands:
-  zombies:
-    description: Type /zombies help for more info!
-    aliases: [z, zo, zom]
+softdepend: [Vault, PlaceholderAPI]

--- a/NMS/1_20_R2/src/main/java/com/theprogrammingturkey/comz/support/support_1_20_R2/NMSUtil_1_20_R2.java
+++ b/NMS/1_20_R2/src/main/java/com/theprogrammingturkey/comz/support/support_1_20_R2/NMSUtil_1_20_R2.java
@@ -72,23 +72,14 @@ public class NMSUtil_1_20_R2 implements INMSUtil
 
 	public void sendParticleToPlayer(NMSParticleType particleType, Player player, Location location, float offsetX, float offsetY, float offsetZ, float speed, int count)
 	{
-		ParticleType particle = Particles.a;
-		switch(particleType)
-		{
-			case WITCH:
-				particle = Particles.ad; // Witch
-				break;
-			case LAVA:
-				particle = Particles.N;
-				break;
-			case FIREWORK:
-				particle = Particles.A;
-				break;
-			case HEART:
-				particle = Particles.G;
-				break;
-		}
-		PacketPlayOutWorldParticles packet = new PacketPlayOutWorldParticles(particle, true, location.getX(), location.getY(), location.getZ(), offsetX, offsetY, offsetZ, speed, count);
+		ParticleType particle = switch (particleType) {
+      case WITCH -> Particles.ad; // Witch
+      case LAVA -> Particles.N;
+      case FIREWORK -> Particles.A;
+      case HEART -> Particles.G;
+      default -> Particles.a;
+    };
+    PacketPlayOutWorldParticles packet = new PacketPlayOutWorldParticles(particle, true, location.getX(), location.getY(), location.getZ(), offsetX, offsetY, offsetZ, speed, count);
 		sendPacket(player, packet);
 	}
 

--- a/NMS/1_20_R3/src/main/java/com/theprogrammingturkey/comz/support/support_1_20_R3/NMSUtil_1_20_R3.java
+++ b/NMS/1_20_R3/src/main/java/com/theprogrammingturkey/comz/support/support_1_20_R3/NMSUtil_1_20_R3.java
@@ -72,23 +72,14 @@ public class NMSUtil_1_20_R3 implements INMSUtil
 
 	public void sendParticleToPlayer(NMSParticleType particleType, Player player, Location location, float offsetX, float offsetY, float offsetZ, float speed, int count)
 	{
-		ParticleType particle = Particles.a;
-		switch(particleType)
-		{
-			case WITCH:
-				particle = Particles.ad; // Witch
-				break;
-			case LAVA:
-				particle = Particles.N;
-				break;
-			case FIREWORK:
-				particle = Particles.A;
-				break;
-			case HEART:
-				particle = Particles.G;
-				break;
-		}
-		PacketPlayOutWorldParticles packet = new PacketPlayOutWorldParticles(particle, true, location.getX(), location.getY(), location.getZ(), offsetX, offsetY, offsetZ, speed, count);
+		ParticleType particle = switch (particleType) {
+      case WITCH -> Particles.ad; // Witch
+      case LAVA -> Particles.N;
+      case FIREWORK -> Particles.A;
+      case HEART -> Particles.G;
+			default -> Particles.a;
+		};
+    PacketPlayOutWorldParticles packet = new PacketPlayOutWorldParticles(particle, true, location.getX(), location.getY(), location.getZ(), offsetX, offsetY, offsetZ, speed, count);
 		sendPacket(player, packet);
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ allprojects {
 subprojects {
     apply plugin: 'java'
 
-    sourceCompatibility = targetCompatibility = '1.8'
+    sourceCompatibility = targetCompatibility = '17'
 
     repositories {
         mavenLocal()


### PR DESCRIPTION
* Fix sign text corrupts. Do not pass `org.bukkit.block.Sign` around since there is no guaranty that it is valid after `org.bukkit.block.Sign#update()`.
* Fix thread-safety issue with `onPlayerChat`.
* Fix gun fires when repairing barrier via sign.
* Fix player was able to change text on sign.
* Fix zombie spawnpoint selection logic.
* Add barrier break and repair progress display.
* Use barrier block count - 1 as max break/fix level.
* Replace RNG with the more modern one.
* And many other low-level fixes, refactors and improvements.

Resolve #97.