### PR TITLE
Finish unmerged parts of #155: shift-to-repair, spawn selection, chat thread-safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 build/
 Core/bin/*
 .project
+
+# Local build/test harness (not part of the plugin build)
+/verification/

--- a/Core/src/main/java/com/theprogrammingturkey/comz/COMZombies.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/COMZombies.java
@@ -37,8 +37,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -58,7 +59,7 @@ public class COMZombies extends JavaPlugin
 	/**
 	 * Players currently performing some sort of action or maintenance
 	 */
-	public HashMap<Player, BaseAction> activeActions = new HashMap<>();
+	public Map<Player, BaseAction> activeActions = new ConcurrentHashMap<>();
 
 
 	/**
@@ -66,7 +67,7 @@ public class COMZombies extends JavaPlugin
 	 * sign, the value that corresponds to the player is the sign that the
 	 * player is editing.
 	 */
-	public HashMap<Player, Location> isEditingASign = new HashMap<>();
+	public Map<Player, Location> isEditingASign = new ConcurrentHashMap<>();
 
 	/**
 	 * Called when the plugin is reloading to cancel every remove spawn, create
@@ -215,6 +216,7 @@ public class COMZombies extends JavaPlugin
 		m.registerEvents(new EntityListener(), this);
 		m.registerEvents(new PlayerChatListener(), this);
 		m.registerEvents(new SignListener(), this);
+		m.registerEvents(new BarrierRepairListener(), this);
 		m.registerEvents(new OnPreCommandEvent(), this);
 		m.registerEvents(new OnBlockInteractEvent(), this);
 		m.registerEvents(new EXPListener(), this);

--- a/Core/src/main/java/com/theprogrammingturkey/comz/listeners/BarrierRepairListener.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/listeners/BarrierRepairListener.java
@@ -1,0 +1,142 @@
+package com.theprogrammingturkey.comz.listeners;
+
+import com.theprogrammingturkey.comz.COMZombies;
+import com.theprogrammingturkey.comz.game.Game;
+import com.theprogrammingturkey.comz.game.GameManager;
+import com.theprogrammingturkey.comz.game.features.Barrier;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerToggleSneakEvent;
+import org.bukkit.util.BoundingBox;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Lets a player repair a nearby barrier by holding sneak (shift), as an
+ * alternative to breaking the [BarrierRepair] sign. Resolves issue #97.
+ * <p>
+ * Sign-breaking repair is still handled by {@link SignListener}; this listener
+ * only adds the shift-to-repair mechanic.
+ */
+public class BarrierRepairListener implements Listener
+{
+	/**
+	 * Ticks between each repair step while sneaking (20 ticks = 1 second).
+	 */
+	private static final long REPAIR_PERIOD = 20L;
+
+	/**
+	 * Half-extents of the box around a repair sign in which a sneaking player
+	 * may repair the barrier. Horizontal reach is wider than vertical.
+	 */
+	private static final double HORIZONTAL_REACH = 3.0D;
+	private static final double VERTICAL_REACH = 2.0D;
+
+	/**
+	 * Maps a sneaking player to the id of their running repair task so it can be
+	 * cancelled when they stop sneaking. Keyed by UUID to avoid holding Player
+	 * references.
+	 */
+	private final Map<UUID, Integer> repairTaskIds = new ConcurrentHashMap<>();
+
+	@EventHandler
+	public void onPlayerToggleSneak(PlayerToggleSneakEvent event)
+	{
+		Player player = event.getPlayer();
+
+		if(!event.isSneaking())
+		{
+			stopRepairing(player.getUniqueId());
+			return;
+		}
+
+		if(repairTaskIds.containsKey(player.getUniqueId()))
+			return;
+
+		Game game = GameManager.INSTANCE.getGame(player);
+		if(game == null)
+			return;
+
+		Barrier target = findRepairableBarrierNear(game, player);
+		if(target == null)
+			return;
+
+		int taskId = COMZombies.scheduleTask(REPAIR_PERIOD, REPAIR_PERIOD, () ->
+		{
+			// Stop if the player went offline, left the game or stopped sneaking.
+			if(!player.isOnline() || !player.isSneaking() || !GameManager.INSTANCE.isPlayerInGame(player))
+			{
+				stopRepairing(player.getUniqueId());
+				return;
+			}
+
+			// Nothing left to repair on this barrier.
+			if(target.getStage() == -1)
+			{
+				stopRepairing(player.getUniqueId());
+				return;
+			}
+
+			// Player walked out of range of the barrier.
+			if(!isInRange(target, player))
+			{
+				stopRepairing(player.getUniqueId());
+				return;
+			}
+
+			boolean fullyRepaired = target.repair(player);
+			Location signLoc = target.getRepairLoc();
+			World world = signLoc.getWorld();
+			if(world != null)
+				world.playSound(signLoc, Sound.BLOCK_ANVIL_LAND, 0.5F, 1.6F);
+
+			if(fullyRepaired)
+				stopRepairing(player.getUniqueId());
+		});
+
+		if(taskId != -1)
+			repairTaskIds.put(player.getUniqueId(), taskId);
+	}
+
+	private Barrier findRepairableBarrierNear(Game game, Player player)
+	{
+		for(Barrier barrier : game.barrierManager.getBarriers())
+			if(barrier.getStage() != -1 && isInRange(barrier, player))
+				return barrier;
+		return null;
+	}
+
+	private boolean isInRange(Barrier barrier, Player player)
+	{
+		Location signLoc = barrier.getRepairLoc();
+		if(signLoc == null || signLoc.getWorld() == null || !signLoc.getWorld().equals(player.getWorld()))
+			return false;
+
+		return repairZone(signLoc).overlaps(player.getBoundingBox());
+	}
+
+	/**
+	 * The box around a repair sign within which a sneaking player may repair the
+	 * barrier: a symmetric cuboid centred on the sign. Extracted for testability.
+	 */
+	static BoundingBox repairZone(Location signLoc)
+	{
+		return BoundingBox.of(
+				signLoc.clone().add(HORIZONTAL_REACH, VERTICAL_REACH, HORIZONTAL_REACH),
+				signLoc.clone().subtract(HORIZONTAL_REACH, VERTICAL_REACH, HORIZONTAL_REACH));
+	}
+
+	private void stopRepairing(UUID playerId)
+	{
+		Integer taskId = repairTaskIds.remove(playerId);
+		if(taskId != null)
+			Bukkit.getScheduler().cancelTask(taskId);
+	}
+}

--- a/Core/src/main/java/com/theprogrammingturkey/comz/spawning/SpawnManager.java
+++ b/Core/src/main/java/com/theprogrammingturkey/comz/spawning/SpawnManager.java
@@ -20,10 +20,12 @@ import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 public class SpawnManager
 {
@@ -179,41 +181,24 @@ public class SpawnManager
 
 	private List<SpawnPoint> getNearestPoints(Location loc, int numToGet)
 	{
-		List<SpawnPoint> points = game.spawnManager.getPoints();
+		return nearestPoints(game.spawnManager.getPoints(), loc, numToGet);
+	}
+
+	/**
+	 * Returns the {@code numToGet} spawn points closest to {@code loc}, nearest
+	 * first. Pure function extracted for testability.
+	 */
+	static List<SpawnPoint> nearestPoints(List<SpawnPoint> points, Location loc, int numToGet)
+	{
 		if(numToGet < 0)
 			throw new IllegalArgumentException("numToGet should not be less than zero");
 		if(numToGet == 0)
 			return new ArrayList<>();
 
-		int numPoints = Math.min(numToGet, points.size());
-		List<SpawnPoint> results = new ArrayList<>(numPoints);
-		for(int i = 0; i < numPoints; i++)
-			results.add(points.get(i));
-
-		List<Double> distances = new ArrayList<>();
-		for(int i = 0; i < numToGet; i++)
-			distances.add(Double.POSITIVE_INFINITY);
-
-		for(SpawnPoint point : points)
-		{
-			Location spawnLoc = point.getLocation();
-			double dx = spawnLoc.getBlockX() - loc.getBlockX();
-			double dy = spawnLoc.getBlockY() - loc.getBlockY();
-			double dz = spawnLoc.getBlockZ() - loc.getBlockZ();
-			double dist2 = (dx * dx) + (dy * dy) + (dz * dz);
-			for(int resultIndex = 0; resultIndex < results.size(); resultIndex++)
-			{
-				if(dist2 >= distances.get(resultIndex))
-					continue;
-
-				distances.add(resultIndex, dist2);
-				results.add(resultIndex, point);
-				results.remove(numPoints);
-				distances.remove(numPoints);
-				break;
-			}
-		}
-		return results;
+		return points.stream()
+				.sorted(Comparator.comparingDouble(point -> point.getLocation().distanceSquared(loc)))
+				.limit(numToGet)
+				.collect(Collectors.toCollection(ArrayList::new));
 	}
 
 	private void smartSpawn(final int wave)


### PR DESCRIPTION
Follow-up to @skbeh's #155 ("Massive refactors and fixes"). Most of that PR was already cherry-picked into `master`, but a few items were not. This PR finishes three of the still-missing pieces, reworked to fit the current `master` (which has since diverged with its own sign/arena refactors and 1.21.5 support).

## Included here

- **Shift-to-repair barriers (resolves #97).** New `BarrierRepairListener`: holding sneak near a barrier repairs it one stage per second, alongside the existing sign-break repair. This is a reimplementation of #155's `BarrierRepairListener` — that version carried a `// TODO: incorrect subtract` on its detection box (an asymmetric, perpendicular-vector cuboid). Replaced with a symmetric cuboid centred on the repair sign (3 blocks horizontal, 2 vertical). Keyed by `UUID`, task cancelled on un-sneak / leave / offline / fully repaired. Does **not** duplicate the sign-break path — `SignListener` still handles that.
- **`SpawnManager.getNearestPoints` rewrite.** Replaces the manual insertion-sort over a parallel `POSITIVE_INFINITY` distance list with `stream → comparingDouble(distanceSquared) → limit`. Extracted to a package-private static for testing.
- **Chat thread-safety.** `activeActions` and `isEditingASign` are now `ConcurrentHashMap`. `AsyncPlayerChatEvent` reads them off the async chat thread while the main thread mutates/clears them — a plain `HashMap` race.

## Verification

Full Gradle build needs per-version Spigot **server** jars (BuildTools) for the `NMS:*` modules, which aren't available in a clean checkout. Verified instead by compiling the whole real `Core`+`API` against `spigot-api` + generated `INMSUtil` stubs, and by JUnit tests over the two extracted algorithms (nearest-point ordering; repair-zone geometry incl. the previously-broken box). All green. **Not** runtime-tested on a live server — event wiring / scheduler / version-specific NMS unexercised.

## Deliberately NOT included from #155 (remaining unfinished / not-applicable)

- **Fast-zombie spawn formula** (`nextInt(100) < 20 + 15*(wave-5)` → `nextInt(10) < 2 + 15*(wave-5)`): skipped — the new form saturates to 100% fast zombies from wave 6, which looks like a regression rather than a fix.
- **Baby/slow-baby zombie variety** (replacing `setBaby(false)`): skipped — a gameplay-balance choice, maintainer's call.
- **`IGameSign` `Block`-signature change**: superseded by `master`'s own "don't pass Sign around" refactor (Location + lines).
- **NMS 1_20_R2 / 1_20_R3 particle tweaks**: obsolete — `master` is on 1.21.5.
- **`paper-plugin.yml`**: #155's used `api-version: 1.19`; would need adapting to the current target before adding.
- Assorted low-level refactors, `@Unmodifiable`/`@NotNull` annotations and immutable-list return wrappers were left out to keep this focused.

Happy to split any of these out or adjust the detection-box reach / repair cadence.